### PR TITLE
Make aws_profile_name optional in update_all_stacks

### DIFF
--- a/src/python/utilities/update_all_stacks.py
+++ b/src/python/utilities/update_all_stacks.py
@@ -41,9 +41,12 @@ def main(aws_profile_name, control_role="OrganizationAccountAccessRole",
             log_with_color(f"Failed to parse custom tags: {str(e)}", "red", "error")
             raise
     
-    # Set the AWS_PROFILE environment variable
-    os.environ['AWS_PROFILE'] = aws_profile_name
-    log_with_color(f"Using AWS profile: {aws_profile_name}", "blue")
+    # Set the AWS_PROFILE environment variable only if explicitly provided
+    if aws_profile_name:
+        os.environ['AWS_PROFILE'] = aws_profile_name
+        log_with_color(f"Using AWS profile: {aws_profile_name}", "blue")
+    else:
+        log_with_color("No AWS profile specified, using default credential chain", "blue")
     
     sts_client = boto3.client('sts')
     try:
@@ -296,7 +299,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="This script will integrate StreamSecurity environment with every account in the organization.")
     parser.add_argument(
-        "--aws_profile_name", help="The AWS profile with admin permissions in organization account", default="default")
+        "--aws_profile_name", help="The AWS profile with admin permissions in organization account (optional, uses default credential chain if not specified)", default=None)
     parser.add_argument(
         "--control_role", help="Specify a role for control", default="OrganizationAccountAccessRole")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Makes `--aws_profile_name` optional (defaults to `None` instead of `"default"`)
- Only sets `AWS_PROFILE` env var when explicitly provided
- Falls back to AWS default credential chain (CloudShell, instance roles, etc.) when no profile is specified

## Test plan
- [x] Tested in AWS CloudShell without specifying a profile — script used default credential chain successfully
- [x] Verified stacks were found and updated correctly in us-east-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CLI/credential-resolution change that mainly affects how AWS credentials are sourced when running the script. Potential impact is limited to environments that previously relied on the implicit `default` profile being forced.
> 
> **Overview**
> `update_all_stacks.py` no longer forces `AWS_PROFILE=default` on every run: `--aws_profile_name` now defaults to `None` and the script only sets `AWS_PROFILE` when a profile is explicitly provided.
> 
> When omitted, the script logs that it will use the AWS *default credential chain* (e.g., CloudShell/instance role), enabling profile-less execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48ad4fd5257e312e158d7784566971ac0e4d5ca2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->