### PR TITLE
Add date range and API token support to export_detections

### DIFF
--- a/main.py
+++ b/main.py
@@ -243,17 +243,17 @@ def export_vulnerabilities(payload: Dict[Any, Any], background_tasks: Background
 @app.post("/export_detections")
 def export_detections(payload: Dict[Any, Any], background_tasks: BackgroundTasks):
     log.info(f"### Export detections requested - {payload['environment_sub_domain'].replace('!', '')}")
-    auth_token = payload.get('auth_token') or None
+    token = payload.get('token') or None
     username = payload.get('environment_user_name') or None
     password = payload.get('environment_password') or None
-    if not auth_token and not (username and password):
+    if not token and not (username and password):
         raise HTTPException(
             status_code=400,
-            detail="Must provide either auth_token or both environment_user_name and environment_password")
+            detail="Must provide either token or both environment_user_name and environment_password")
     arguments = [payload['environment_sub_domain'].replace('!', ''), username, password,
                  payload.get('environment_f2a_token') or None, payload['ws_name'],
                  payload['start_time'], payload['end_time']]
-    kwargs = {'token': auth_token}
+    kwargs = {'token': token}
     if payload['environment_sub_domain'].startswith('!'):
         kwargs['stage'] = True
     try:

--- a/main.py
+++ b/main.py
@@ -265,6 +265,8 @@ def export_detections(payload: Dict[Any, Any], background_tasks: BackgroundTasks
         background_tasks.add_task(remove_file, file_name)
         with open(file_name) as csv_file:
             return StreamingResponse(iter([csv_file.read()]), headers=headers)
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -243,13 +243,21 @@ def export_vulnerabilities(payload: Dict[Any, Any], background_tasks: Background
 @app.post("/export_detections")
 def export_detections(payload: Dict[Any, Any], background_tasks: BackgroundTasks):
     log.info(f"### Export detections requested - {payload['environment_sub_domain'].replace('!', '')}")
-    arguments = [payload['environment_sub_domain'].replace('!', ''), payload['environment_user_name'],
-                 payload['environment_password'], payload.get('environment_f2a_token', None), payload['ws_name'],
-                 payload.get('accounts', None)]
+    auth_token = payload.get('auth_token') or None
+    username = payload.get('environment_user_name') or None
+    password = payload.get('environment_password') or None
+    if not auth_token and not (username and password):
+        raise HTTPException(
+            status_code=400,
+            detail="Must provide either auth_token or both environment_user_name and environment_password")
+    arguments = [payload['environment_sub_domain'].replace('!', ''), username, password,
+                 payload.get('environment_f2a_token') or None, payload['ws_name'],
+                 payload['start_time'], payload['end_time']]
+    kwargs = {'token': auth_token}
     if payload['environment_sub_domain'].startswith('!'):
-        arguments.append("true")
+        kwargs['stage'] = True
     try:
-        file_name = export_enriched_detections.main(*arguments)
+        file_name = export_enriched_detections.main(*arguments, **kwargs)
         headers = {
             'Content-Type': 'text/csv',
             'Content-Disposition': f'attachment; filename="{file_name}"'

--- a/main.py
+++ b/main.py
@@ -265,6 +265,8 @@ def export_detections(payload: Dict[Any, Any], background_tasks: BackgroundTasks
         background_tasks.add_task(remove_file, file_name)
         with open(file_name) as csv_file:
             return StreamingResponse(iter([csv_file.read()]), headers=headers)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/src/python/common/common.py
+++ b/src/python/common/common.py
@@ -27,6 +27,8 @@ def get_graph_client(environment, ll_username, ll_password, ll_f2a, ws_name, sta
         if token:
             # API tokens are workspace-scoped; the `workspaces` query isn't available,
             # so ws_name must be the workspace ID and we use it directly as customer_id.
+            if not ws_name:
+                raise ValueError("Workspace ID is required when authenticating with an API token")
             graph_client = GraphCommon(ll_graph_url, otp=ll_f2a, token=token, customer_id=ws_name)
         else:
             graph_client = GraphCommon(ll_graph_url, ll_username, ll_password, otp=ll_f2a)

--- a/src/python/common/common.py
+++ b/src/python/common/common.py
@@ -17,17 +17,22 @@ if len(log.handlers) == 0:
     log = Logger().get_logger()
 
 
-def get_graph_client(environment, ll_username, ll_password, ll_f2a, ws_name, stage):
+def get_graph_client(environment, ll_username, ll_password, ll_f2a, ws_name, stage, token=None):
     log.info(f"Trying to login into Stream in environment {environment}")
     ll_url = f"https://{environment}.streamsec.io"
     if stage:
         ll_url = f"https://{environment}.lightops.io"
     ll_graph_url = f"{ll_url}/graphql"
     try:
-        graph_client = GraphCommon(ll_graph_url, ll_username, ll_password, otp=ll_f2a)
-        if ws_name:
-            ws_id = graph_client.get_ws_id_by_name(ws_name)
-            graph_client.change_client_ws(ws_id)
+        if token:
+            # API tokens are workspace-scoped; the `workspaces` query isn't available,
+            # so ws_name must be the workspace ID and we use it directly as customer_id.
+            graph_client = GraphCommon(ll_graph_url, otp=ll_f2a, token=token, customer_id=ws_name)
+        else:
+            graph_client = GraphCommon(ll_graph_url, ll_username, ll_password, otp=ll_f2a)
+            if ws_name:
+                ws_id = graph_client.get_ws_id_by_name(ws_name)
+                graph_client.change_client_ws(ws_id)
         log.info("Logged in successfully!")
         return graph_client
     except Exception as e:

--- a/src/python/common/graph_common.py
+++ b/src/python/common/graph_common.py
@@ -5,20 +5,24 @@ import time
 
 
 class GraphCommon(object):
-    def __init__(self, url, email, pw, customer_id=None, otp=None):
+    def __init__(self, url, email=None, pw=None, customer_id=None, otp=None, token=None):
         """ Initialize GraphCommon class to graph functions.
             :param url (str)            - The url of the environment.
             :param email (str)          - The email for login.
             :param pw (str)             - The password for login.
             :param otp (str)            - 2FA token.
             :param customer_id (str)    - The customer ID for operations; Defaults to the Demo Customer ID.
+            :param token (str)          - Pre-existing API token; if provided, skips email/pw login.
         """
         self.url = url
         self.email = email
         self.pw = pw
-        self.token = self.get_token(email, pw)
-        if otp:
-            self.token = self.get_token_otp(otp, self.token)
+        if token:
+            self.token = token if token.startswith('Bearer ') else f'Bearer {token}'
+        else:
+            self.token = self.get_token(email, pw)
+            if otp:
+                self.token = self.get_token_otp(otp, self.token)
         time.sleep(2)
         self.customer_id = customer_id or self.get_customer_id()
 
@@ -805,15 +809,23 @@ class GraphCommon(object):
             variables['filters']['protocol'] = protocols.split(",")
         return self.graph_query(operation, variables, query)['data']['IPTraffic']['results']
 
-    def get_detections(self):
+    def get_detections(self, page_size=500):
         operation = 'Detections'
-        variables = {"filters": {"acknowledged": True}}
         query = ("query Detections($filters: DetectionsFilters, $sort: DetectionsSort, $skip: Int, $limit: Int){"
                  "get_detections(filters: $filters, sort: $sort, skip: $skip, limit: $limit){total_count results{_id "
                  "timestamp activity_type source account_id anomaly_severity resource_id resource_type "
                  "mitre_categories acknowledged acknowledgement_details{timestamp user reason __typename}signal_types "
                  "__typename}__typename}}")
-        return self.graph_query(operation, variables, query)['data']['get_detections']['results']
+        all_results = []
+        skip = 0
+        while True:
+            variables = {"filters": {}, "skip": skip, "limit": page_size}
+            batch = self.graph_query(operation, variables, query)['data']['get_detections']['results']
+            all_results.extend(batch)
+            if len(batch) < page_size:
+                break
+            skip += page_size
+        return all_results
 
     def get_detection_enrichment(self, detection_id):
         operation = 'Detection'

--- a/src/python/common/graph_common.py
+++ b/src/python/common/graph_common.py
@@ -810,6 +810,8 @@ class GraphCommon(object):
         return self.graph_query(operation, variables, query)['data']['IPTraffic']['results']
 
     def get_detections(self, page_size=500):
+        # 500 per page balances fewer round-trips against request payload size;
+        # the server's default implicit limit was dropping results beyond ~100.
         operation = 'Detections'
         query = ("query Detections($filters: DetectionsFilters, $sort: DetectionsSort, $skip: Int, $limit: Int){"
                  "get_detections(filters: $filters, sort: $sort, skip: $skip, limit: $limit){total_count results{_id "
@@ -1081,6 +1083,10 @@ class GraphCommon(object):
         res = requests.post(self.url, json=payload, headers={"Authorization": self.token, "customer": customer_id})
         if bool(res):
             if 'UNAUTHENTICATED' in str(json.loads(res.text)):
+                # Token-auth sessions have no credentials to re-authenticate with;
+                # surface the original failure instead of calling get_token(None, None).
+                if not self.email or not self.pw:
+                    return json.loads(res.text)
                 self.token = self.get_token(self.email, self.pw)
                 res = requests.post(self.url, json=payload, headers={"Authorization": self.token})
             return json.loads(res.text)

--- a/src/python/common/graph_common.py
+++ b/src/python/common/graph_common.py
@@ -18,6 +18,8 @@ class GraphCommon(object):
         self.email = email
         self.pw = pw
         if token:
+            if not isinstance(token, str):
+                raise ValueError(f"token must be a string, got {type(token).__name__}")
             self.token = token if token.startswith('Bearer ') else f'Bearer {token}'
         else:
             self.token = self.get_token(email, pw)
@@ -1088,7 +1090,9 @@ class GraphCommon(object):
                 if not self.email or not self.pw:
                     return json.loads(res.text)
                 self.token = self.get_token(self.email, self.pw)
-                res = requests.post(self.url, json=payload, headers={"Authorization": self.token})
+                res = requests.post(
+                    self.url, json=payload,
+                    headers={"Authorization": self.token, "customer": customer_id})
             return json.loads(res.text)
         else:
             print(f"res: {res}")

--- a/src/python/utilities/export_detections.py
+++ b/src/python/utilities/export_detections.py
@@ -2,6 +2,7 @@ import argparse
 import concurrent.futures
 import csv
 import os
+import re
 import sys
 from datetime import datetime, timezone
 
@@ -17,17 +18,26 @@ except ModuleNotFoundError:
 def _parse_timestamp(ts):
     if ts is None:
         return datetime.min.replace(tzinfo=timezone.utc)
-    if isinstance(ts, (int, float)):
+    # bool is a subclass of int in Python — exclude it explicitly so True/False
+    # don't get treated as Unix timestamps (1970-01-01 00:00:01 / epoch).
+    if isinstance(ts, (int, float)) and not isinstance(ts, bool):
         # Unix epoch: detect milliseconds vs seconds
         if ts > 1e12:
             ts = ts / 1000
         return datetime.fromtimestamp(ts, tz=timezone.utc)
     if isinstance(ts, str):
-        dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+        try:
+            dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+        except ValueError:
+            log.warning(f"Could not parse timestamp string {ts!r}; excluding detection from range")
+            return datetime.min.replace(tzinfo=timezone.utc)
         # Force UTC on naive datetimes (e.g. "2024-01-15T10:30:00" with no offset)
         # so the later comparison against tz-aware bounds doesn't crash.
         return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
-    raise ValueError(f"Unsupported timestamp type: {type(ts).__name__}")
+    # Unknown type (dict/list/bool/etc. — possible if the GraphQL schema changes):
+    # log a warning and exclude the detection rather than killing the whole export.
+    log.warning(f"Unsupported timestamp type {type(ts).__name__} ({ts!r}); excluding detection from range")
+    return datetime.min.replace(tzinfo=timezone.utc)
 
 
 def enrich_detections(graph_client, detection):
@@ -74,11 +84,14 @@ def main(environment, ll_username, ll_password, ll_f2a, ws_name, start_time, end
             if exc is not None:
                 log.warning(f"Detection enrichment failed: {exc}")
 
-    # Get columns names
+    # Get column names
     column_names = list(filtered_detections[0].keys())
 
-    # Set CSV file name
-    csv_file = f'{environment.upper()} enriched detections export {start_time} {end_time}.csv'
+    # Sanitize the user-supplied environment slug before using it in a filesystem
+    # path (defense-in-depth against path traversal — login would normally fail
+    # first on a hostile value, but we don't rely on that).
+    safe_env = re.sub(r'[^A-Za-z0-9._-]', '_', environment).upper() or 'EXPORT'
+    csv_file = f'{safe_env} enriched detections export {start_time} {end_time}.csv'
 
     log.info(f'Generating CSV file, file name: "{csv_file}"')
     try:

--- a/src/python/utilities/export_detections.py
+++ b/src/python/utilities/export_detections.py
@@ -14,17 +14,40 @@ except ModuleNotFoundError:
     from src.python.common.common import *
 
 
+def _parse_timestamp(ts):
+    if ts is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if isinstance(ts, (int, float)):
+        # Unix epoch: detect milliseconds vs seconds
+        if ts > 1e12:
+            ts = ts / 1000
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
+    if isinstance(ts, str):
+        dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+        # Force UTC on naive datetimes (e.g. "2024-01-15T10:30:00" with no offset)
+        # so the later comparison against tz-aware bounds doesn't crash.
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    raise ValueError(f"Unsupported timestamp type: {type(ts).__name__}")
+
+
+def enrich_detections(graph_client, detection):
+    detection_enrichment = graph_client.get_detection_enrichment(detection['_id'])[0]
+    detection["enrichment"] = {k: v for k, v in detection_enrichment.items() if k not in detection}
+
+
 def main(environment, ll_username, ll_password, ll_f2a, ws_name, start_time, end_time, token=None, stage=None):
-    # Validate date format
+    # Validate date format (raises ValueError on bad input, surfaced as 400 by main.py)
     for date_to_check in [start_time, end_time]:
         datetime.strptime(date_to_check, "%Y-%m-%d")
     if datetime.strptime(start_time, "%Y-%m-%d") > datetime.strptime(end_time, "%Y-%m-%d"):
-        raise Exception(f"Start time {start_time} is after end time {end_time}")
+        raise ValueError(f"Start time {start_time} is after end time {end_time}")
 
     # Connecting to Stream
     graph_client = get_graph_client(environment, ll_username, ll_password, ll_f2a, ws_name, stage, token=token)
 
     # Get all detections
+    # TODO: push the timestamp filter into the GraphQL `DetectionsFilters` input
+    # and drop the client-side filter once the schema is verified against a live env.
     log.info("Get all detections")
     all_detections = graph_client.get_detections()
     log.info(f"Found {len(all_detections)} detections")
@@ -38,7 +61,7 @@ def main(environment, ll_username, ll_password, ll_f2a, ws_name, start_time, end
     log.info(f"Filtered to {len(filtered_detections)} detections between {start_time} and {end_time}")
 
     if not filtered_detections:
-        raise Exception(f"No detections found in the range {start_time} to {end_time}")
+        raise ValueError(f"No detections found in the range {start_time} to {end_time}")
 
     # Enrich detections
     with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -58,24 +81,6 @@ def main(environment, ll_username, ll_password, ll_f2a, ws_name, start_time, end
     log.info("File generated successfully, export complete!")
 
     return csv_file
-
-
-def _parse_timestamp(ts):
-    if ts is None:
-        return datetime.min.replace(tzinfo=timezone.utc)
-    if isinstance(ts, (int, float)):
-        # Unix epoch: detect milliseconds vs seconds
-        if ts > 1e12:
-            ts = ts / 1000
-        return datetime.fromtimestamp(ts, tz=timezone.utc)
-    if isinstance(ts, str):
-        return datetime.fromisoformat(ts.replace('Z', '+00:00'))
-    raise ValueError(f"Unsupported timestamp type: {type(ts).__name__}")
-
-
-def enrich_detections(graph_client, detection):
-    detection_enrichment = graph_client.get_detection_enrichment(detection['_id'])[0]
-    detection["enrichment"] = {k: v for k, v in detection_enrichment.items() if k not in detection}
 
 
 if __name__ == "__main__":

--- a/src/python/utilities/export_detections.py
+++ b/src/python/utilities/export_detections.py
@@ -36,10 +36,14 @@ def enrich_detections(graph_client, detection):
 
 
 def main(environment, ll_username, ll_password, ll_f2a, ws_name, start_time, end_time, token=None, stage=None):
-    # Validate date format (raises ValueError on bad input, surfaced as 400 by main.py)
-    for date_to_check in [start_time, end_time]:
-        datetime.strptime(date_to_check, "%Y-%m-%d")
-    if datetime.strptime(start_time, "%Y-%m-%d") > datetime.strptime(end_time, "%Y-%m-%d"):
+    # Parse and validate dates once (ValueError surfaces as 400 in main.py)
+    try:
+        start_dt = datetime.strptime(start_time, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        end_dt = datetime.strptime(end_time, "%Y-%m-%d").replace(
+            hour=23, minute=59, second=59, microsecond=999999, tzinfo=timezone.utc)
+    except ValueError as e:
+        raise ValueError(f"Dates must be in YYYY-MM-DD format: {e}")
+    if start_dt > end_dt:
         raise ValueError(f"Start time {start_time} is after end time {end_time}")
 
     # Connecting to Stream
@@ -52,20 +56,23 @@ def main(environment, ll_username, ll_password, ll_f2a, ws_name, start_time, end
     all_detections = graph_client.get_detections()
     log.info(f"Found {len(all_detections)} detections")
 
-    # Filter by time range
-    start_dt = datetime.strptime(start_time, "%Y-%m-%d").replace(tzinfo=timezone.utc)
-    end_dt = datetime.strptime(end_time, "%Y-%m-%d").replace(
-        hour=23, minute=59, second=59, microsecond=999999, tzinfo=timezone.utc)
+    # Filter by time range (client-side; see TODO above)
     filtered_detections = [d for d in all_detections
                            if start_dt <= _parse_timestamp(d.get('timestamp')) <= end_dt]
     log.info(f"Filtered to {len(filtered_detections)} detections between {start_time} and {end_time}")
 
     if not filtered_detections:
-        raise ValueError(f"No detections found in the range {start_time} to {end_time}")
+        # LookupError is mapped to HTTP 404 in main.py — request was valid, nothing matched.
+        raise LookupError(f"No detections found in the range {start_time} to {end_time}")
 
-    # Enrich detections
+    # Enrich detections — surface individual failures in the log rather than silently discarding
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        [executor.submit(enrich_detections, graph_client, detection) for detection in filtered_detections]
+        futures = [executor.submit(enrich_detections, graph_client, detection)
+                   for detection in filtered_detections]
+        for future in concurrent.futures.as_completed(futures):
+            exc = future.exception()
+            if exc is not None:
+                log.warning(f"Detection enrichment failed: {exc}")
 
     # Get columns names
     column_names = list(filtered_detections[0].keys())
@@ -74,10 +81,19 @@ def main(environment, ll_username, ll_password, ll_f2a, ws_name, start_time, end
     csv_file = f'{environment.upper()} enriched detections export {start_time} {end_time}.csv'
 
     log.info(f'Generating CSV file, file name: "{csv_file}"')
-    with open(csv_file, mode='w', newline='') as file:
-        writer = csv.DictWriter(file, fieldnames=column_names, extrasaction='ignore')
-        writer.writeheader()
-        writer.writerows(filtered_detections)
+    try:
+        with open(csv_file, mode='w', newline='') as file:
+            writer = csv.DictWriter(file, fieldnames=column_names, extrasaction='ignore')
+            writer.writeheader()
+            writer.writerows(filtered_detections)
+    except Exception:
+        # Clean up partially-written file so it doesn't linger on disk
+        if os.path.exists(csv_file):
+            try:
+                os.unlink(csv_file)
+            except OSError:
+                pass
+        raise
     log.info("File generated successfully, export complete!")
 
     return csv_file

--- a/src/python/utilities/export_detections.py
+++ b/src/python/utilities/export_detections.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import csv
 import os
 import sys
+from datetime import datetime, timezone
 
 # Add the project root directory to the Python path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
@@ -13,33 +14,63 @@ except ModuleNotFoundError:
     from src.python.common.common import *
 
 
-def main(environment, ll_username, ll_password, ll_f2a, ws_name, stage=None):
+def main(environment, ll_username, ll_password, ll_f2a, ws_name, start_time, end_time, token=None, stage=None):
+    # Validate date format
+    for date_to_check in [start_time, end_time]:
+        datetime.strptime(date_to_check, "%Y-%m-%d")
+    if datetime.strptime(start_time, "%Y-%m-%d") > datetime.strptime(end_time, "%Y-%m-%d"):
+        raise Exception(f"Start time {start_time} is after end time {end_time}")
+
     # Connecting to Stream
-    graph_client = get_graph_client(environment, ll_username, ll_password, ll_f2a, ws_name, stage)
+    graph_client = get_graph_client(environment, ll_username, ll_password, ll_f2a, ws_name, stage, token=token)
 
     # Get all detections
     log.info("Get all detections")
     all_detections = graph_client.get_detections()
     log.info(f"Found {len(all_detections)} detections")
 
+    # Filter by time range
+    start_dt = datetime.strptime(start_time, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    end_dt = datetime.strptime(end_time, "%Y-%m-%d").replace(
+        hour=23, minute=59, second=59, microsecond=999999, tzinfo=timezone.utc)
+    filtered_detections = [d for d in all_detections
+                           if start_dt <= _parse_timestamp(d.get('timestamp')) <= end_dt]
+    log.info(f"Filtered to {len(filtered_detections)} detections between {start_time} and {end_time}")
+
+    if not filtered_detections:
+        raise Exception(f"No detections found in the range {start_time} to {end_time}")
+
     # Enrich detections
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        [executor.submit(enrich_detections, graph_client, detection) for detection in all_detections]
+        [executor.submit(enrich_detections, graph_client, detection) for detection in filtered_detections]
 
     # Get columns names
-    column_names = list(all_detections[0].keys())
+    column_names = list(filtered_detections[0].keys())
 
     # Set CSV file name
-    csv_file = f'{environment.upper()} enriched detections export.csv'
+    csv_file = f'{environment.upper()} enriched detections export {start_time} {end_time}.csv'
 
     log.info(f'Generating CSV file, file name: "{csv_file}"')
     with open(csv_file, mode='w', newline='') as file:
         writer = csv.DictWriter(file, fieldnames=column_names, extrasaction='ignore')
         writer.writeheader()
-        writer.writerows(all_detections)
+        writer.writerows(filtered_detections)
     log.info("File generated successfully, export complete!")
 
     return csv_file
+
+
+def _parse_timestamp(ts):
+    if ts is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if isinstance(ts, (int, float)):
+        # Unix epoch: detect milliseconds vs seconds
+        if ts > 1e12:
+            ts = ts / 1000
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
+    if isinstance(ts, str):
+        return datetime.fromisoformat(ts.replace('Z', '+00:00'))
+    raise ValueError(f"Unsupported timestamp type: {type(ts).__name__}")
 
 
 def enrich_detections(graph_client, detection):
@@ -53,15 +84,23 @@ if __name__ == "__main__":
     parser.add_argument(
         "--environment_sub_domain", help="The Stream environment sub domain", required=True)
     parser.add_argument(
-        "--environment_user_name", help="The Stream environment user name", required=True)
+        "--environment_user_name", help="The Stream environment user name", default=None)
     parser.add_argument(
-        "--environment_password", help="The Stream environment password", required=True)
+        "--environment_password", help="The Stream environment password", default=None)
     parser.add_argument(
         "--environment_f2a_token", help="F2A Token if set", default=None)
     parser.add_argument(
         "--ws_name", help="The WS from which to fetch information", required=True)
     parser.add_argument(
+        "--start_time", help="Start date for detections, format: 'YYYY-MM-DD'", required=True)
+    parser.add_argument(
+        "--end_time", help="End date for detections, format: 'YYYY-MM-DD'", required=True)
+    parser.add_argument(
+        "--token", help="API token; alternative to user/password login", default=None)
+    parser.add_argument(
         "--stage", action="store_true")
     args = parser.parse_args()
+    if not args.token and not (args.environment_user_name and args.environment_password):
+        parser.error("Must provide either --token or both --environment_user_name and --environment_password")
     main(args.environment_sub_domain, args.environment_user_name, args.environment_password, args.environment_f2a_token,
-         args.ws_name, stage=args.stage)
+         args.ws_name, args.start_time, args.end_time, token=args.token, stage=args.stage)

--- a/static/script.js
+++ b/static/script.js
@@ -93,7 +93,7 @@ document.addEventListener("DOMContentLoaded", function () {
             { name: "environment_password", type: "password", placeholder: "Enter Password (leave blank if using token)", displayName: "Environment Password (leave blank if using API token)" },
             { name: "environment_f2a_token", type: "password", placeholder: "Leave blank if F2A not set" },
             { name: "ws_name", type: "text", placeholder: "Workspace name for user/password login, or workspace ID when using API token", required: true, displayName: "Workspace (Name for user/password, ID for API token)" },
-            { name: "auth_token", type: "password", placeholder: "Paste API token here (alternative to user/password login)", displayName: "API Token (alternative to user/password)" },
+            { name: "token", type: "password", placeholder: "Paste API token here (alternative to user/password login)", displayName: "API Token (alternative to user/password)" },
             { name: "start_time", type: "date", required: true, displayName: "Start Date" },
             { name: "end_time", type: "date", required: true, displayName: "End Date" }
         ]

--- a/static/script.js
+++ b/static/script.js
@@ -88,7 +88,14 @@ document.addEventListener("DOMContentLoaded", function () {
             }
         ],
         "/export_detections": [
-            ...defaultParameters
+            { name: "environment_sub_domain", type: "text", placeholder: "Enter Sub Domain", required: true },
+            { name: "environment_user_name", type: "text", placeholder: "Enter User Name (leave blank if using token)", displayName: "Environment User Name (leave blank if using API token)" },
+            { name: "environment_password", type: "password", placeholder: "Enter Password (leave blank if using token)", displayName: "Environment Password (leave blank if using API token)" },
+            { name: "environment_f2a_token", type: "password", placeholder: "Leave blank if F2A not set" },
+            { name: "ws_name", type: "text", placeholder: "Workspace name for user/password login, or workspace ID when using API token", required: true, displayName: "Workspace (Name for user/password, ID for API token)" },
+            { name: "auth_token", type: "password", placeholder: "Paste API token here (alternative to user/password login)", displayName: "API Token (alternative to user/password)" },
+            { name: "start_time", type: "date", required: true, displayName: "Start Date" },
+            { name: "end_time", type: "date", required: true, displayName: "End Date" }
         ]
     };
 
@@ -122,19 +129,19 @@ document.addEventListener("DOMContentLoaded", function () {
                     selectElement.appendChild(optionElement);
                 });
 
-                const displayName = parameterDisplayNames[parameter.name] || parameter.displayName || parameter.name;
+                const displayName = parameter.displayName || parameterDisplayNames[parameter.name] || parameter.name;
                 inputGroup.innerHTML = `
                     <label for="${parameter.name}" class="form-label">${displayName}</label>
                 `;
                 inputGroup.appendChild(selectElement);
             } else if (parameter.type === "boolean") {
-                const displayName = parameterDisplayNames[parameter.name] || parameter.name;
+                const displayName = parameter.displayName || parameterDisplayNames[parameter.name] || parameter.name;
                 inputGroup.innerHTML = `
                     <label for="${parameter.name}" class="form-label">${displayName}</label>
                     <input type="checkbox" class="form-check-input" id="${parameter.name}" name="${parameter.name}">
                 `;
             } else {
-                const displayName = parameterDisplayNames[parameter.name] || parameter.name;
+                const displayName = parameter.displayName || parameterDisplayNames[parameter.name] || parameter.name;
                 inputGroup.innerHTML = `
                     <label for="${parameter.name}" class="form-label">${displayName}</label>
                     <input type="${parameter.type}" class="form-control" id="${parameter.name}" name="${parameter.name}" placeholder="${parameter.placeholder}" ${parameter.required ? "required" : ""}>


### PR DESCRIPTION
## Summary
- New required **Start Date** / **End Date** filters for Export Detections — the generated CSV now only includes detections within the chosen range, and the filename includes the range
- Added **API token** auth as an alternative to username/password login (token is workspace-scoped, so the Workspace field takes the workspace ID in token mode)
- Fixed a pre-existing bug in `main.py` where the payload `accounts` value was silently passed as the `stage` argument of `export_detections.main()`
- `GraphCommon.get_detections()` now paginates through all results and no longer filters to `acknowledged=True`, so unacknowledged + older detections are included
- Backwards-compatible `token=` param added to `GraphCommon.__init__` and `get_graph_client()` — existing callers unaffected

## Test plan
- [x] User/password flow (existing): username + password + ws name + dates → CSV generated
- [x] Token flow (new): API token + workspace ID + dates → CSV generated
- [x] Submitting with neither auth method → 400 error
- [x] Date range narrows the CSV content correctly
- [x] Pagination picks up detections beyond the previous ~100-item default limit
- [x] Tested locally on `http://127.0.0.1:8000`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an alternative authentication path (API token) and changes detection retrieval to paginate and include more results, which can affect access, performance, and exported data volume/content.
> 
> **Overview**
> `/export_detections` now requires `start_time`/`end_time`, validates the range, filters detections to that window, and includes the dates in the generated CSV filename.
> 
> Adds API-token authentication as an alternative to username/password for detection export (including UI form updates), passing `token` through `get_graph_client()`/`GraphCommon` and treating `ws_name` as a workspace ID in token mode.
> 
> Updates `GraphCommon.get_detections()` to paginate through all detections (and no longer restrict to `acknowledged=True`), and fixes the `stage` handling in `main.py` by switching to keyword arguments instead of appending a positional flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 866542ee5cbc75b1a7d1b0ce107e4783d7f8779f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->