### PR TITLE
Add API token auth, AWS profile support, and bug fixes to org integration Lambda

### DIFF
--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -5,10 +5,28 @@ import concurrent.futures
 from src.python.common.boto_common import *
 from src.python.common.graph_common import GraphCommon
 
+
+class GraphCommonToken(GraphCommon):
+    """GraphCommon variant authenticated with a long-lived API token.
+
+    Bypasses the email/password login in the base __init__ so no Login mutation
+    is issued. If the token is ever rejected, graph_query's auto-refresh branch
+    will fail fast since email/pw are None — that's intentional: with an API
+    token there's nothing to refresh to.
+    """
+    def __init__(self, url, api_token, customer_id=None):
+        self.url = url
+        self.email = None
+        self.pw = None
+        self.token = api_token if api_token.startswith("Bearer ") else f"Bearer {api_token}"
+        self.customer_id = customer_id or self.get_customer_id()
+
+
 def lambda_handler(event, context):
     # Extract parameters from environment variables
     environment = os.environ.get('ENVIRONMENT')
     domain = os.environ.get('ENVIRONMENT_DOMAIN', 'streamsec.io')
+    ll_api_token = os.environ.get('API_TOKEN')
     ll_username = os.environ.get('ENVIRONMENT_USER_NAME')
     ll_password = os.environ.get('ENVIRONMENT_PASSWORD')
     accounts = os.environ.get('ACCOUNTS', None)
@@ -40,7 +58,12 @@ def lambda_handler(event, context):
 
     print(f"Trying to login into Stream Security environment: {environment}")
     ll_url = f"https://{environment}.{domain}/graphql"
-    graph_client = GraphCommon(ll_url, ll_username, ll_password, ws_id)
+    if ll_api_token:
+        graph_client = GraphCommonToken(ll_url, ll_api_token, ws_id)
+    elif ll_username and ll_password:
+        graph_client = GraphCommon(ll_url, ll_username, ll_password, ws_id)
+    else:
+        raise Exception("Missing Stream Security credentials: set API_TOKEN, or both ENVIRONMENT_USER_NAME and ENVIRONMENT_PASSWORD")
     print("Logged in successfully!")
 
     print("Creating Boto3 Session")

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -13,6 +13,10 @@ class GraphCommonToken(GraphCommon):
     is issued. If the token is ever rejected, graph_query's auto-refresh branch
     will fail fast since email/pw are None — that's intentional: with an API
     token there's nothing to refresh to.
+
+    Maintenance note: this class deliberately does NOT call super().__init__().
+    If GraphCommon.__init__ ever adds non-login setup (e.g. a shared session,
+    default headers, retry config), mirror that setup here.
     """
     def __init__(self, url, api_token, customer_id=None):
         self.url = url

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -120,7 +120,7 @@ def lambda_handler(event, context):
                 integrate_sub_account(
                     sub_account, sts_client, graph_client, regions, random_int,
                     custom_tags, regions_to_integrate, control_role, org_account_id,
-                    response, response_region, response_exclude_runbooks, environment, domain,
+                    parallel, response, response_region, response_exclude_runbooks, environment, domain,
                     eks_audit_logs, eks_audit_logs_regions
                 )
             except Exception as e:

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -224,8 +224,11 @@ def integrate_sub_account(
         # If account is not already integrated to StreamSecurity
         if not ll_integrated:
             print(color(f"Account: {sub_account[0]} | Creating account in StreamSecurity", "blue"))
-            graph_client.create_account(
-                sub_account[0], [sub_account_session.region_name], display_name=sub_account[1])
+            if not graph_client.create_account(
+                    sub_account[0], [sub_account_session.region_name], display_name=sub_account[1]):
+                err_msg = f"Account: {sub_account[0]} | Failed to create account in StreamSecurity"
+                print(color(err_msg, "red"))
+                raise Exception(err_msg)
             print(color(f"Account: {sub_account[0]} | Account created successfully", "green"))
 
         print(color(f"Account: {sub_account[0]} | Fetching relevant account information", "blue"))

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -2,6 +2,7 @@ import boto3
 import random
 import os
 import concurrent.futures
+from botocore.exceptions import ClientError
 from src.python.common.boto_common import *
 from src.python.common.graph_common import GraphCommon
 
@@ -124,10 +125,16 @@ def integrate_sub_account(
         if sub_account[0] == org_account_id:
             sub_account_session = boto3.Session()
         else:
-            assumed_role = sts_client.assume_role(
-                RoleArn=f'arn:aws:iam::{sub_account[0]}:role/{control_role}',
-                RoleSessionName='MySessionName'
-            )
+            role_arn = f'arn:aws:iam::{sub_account[0]}:role/{control_role}'
+            try:
+                assumed_role = sts_client.assume_role(
+                    RoleArn=role_arn,
+                    RoleSessionName='MySessionName'
+                )
+            except ClientError as e:
+                err_msg = f"Account: {sub_account[0]} | Failed to assume {role_arn}: {e}"
+                print(color(err_msg, "red"))
+                raise Exception(err_msg) from e
             print(color(f"Account: {sub_account[0]} | Initializing Boto session", "blue"))
             sub_account_session = boto3.Session(
                 aws_access_key_id=assumed_role['Credentials']['AccessKeyId'],

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -8,26 +8,6 @@ from src.python.common.boto_common import *
 from src.python.common.graph_common import GraphCommon
 
 
-class GraphCommonToken(GraphCommon):
-    """GraphCommon variant authenticated with a long-lived API token.
-
-    Bypasses the email/password login in the base __init__ so no Login mutation
-    is issued. If the token is ever rejected, graph_query's auto-refresh branch
-    will fail fast since email/pw are None — that's intentional: with an API
-    token there's nothing to refresh to.
-
-    Maintenance note: this class deliberately does NOT call super().__init__().
-    If GraphCommon.__init__ ever adds non-login setup (e.g. a shared session,
-    default headers, retry config), mirror that setup here.
-    """
-    def __init__(self, url, api_token, customer_id=None):
-        self.url = url
-        self.email = None
-        self.pw = None
-        self.token = api_token if api_token.startswith("Bearer ") else f"Bearer {api_token}"
-        self.customer_id = customer_id or self.get_customer_id()
-
-
 def lambda_handler(event, context):
     # Extract parameters from environment variables
     environment = os.environ.get('ENVIRONMENT')
@@ -65,7 +45,7 @@ def lambda_handler(event, context):
     print(f"Trying to login into Stream Security environment: {environment}")
     ll_url = f"https://{environment}.{domain}/graphql"
     if ll_api_token:
-        graph_client = GraphCommonToken(ll_url, ll_api_token, ws_id)
+        graph_client = GraphCommon(ll_url, token=ll_api_token, customer_id=ws_id)
     elif ll_username and ll_password:
         graph_client = GraphCommon(ll_url, ll_username, ll_password, ws_id)
     else:

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -1,6 +1,7 @@
 import boto3
 import random
 import os
+import time
 import concurrent.futures
 from botocore.exceptions import ClientError
 from src.python.common.boto_common import *

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -95,24 +95,41 @@ def lambda_handler(event, context):
 
     print(f"Accounts to-be integrated: {[sa[0] for sa in sub_accounts]}")
 
+    failures = []
     if parallel:
         with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as executor:
-            results = [executor.submit(
-                integrate_sub_account,
-                sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate,
-                control_role, org_account_id, parallel,
-                response, response_region, response_exclude_runbooks, environment, domain,
-                eks_audit_logs, eks_audit_logs_regions
-            ) for sub_account in sub_accounts]
-            concurrent.futures.wait(results)
+            future_to_account = {
+                executor.submit(
+                    integrate_sub_account,
+                    sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate,
+                    control_role, org_account_id, parallel,
+                    response, response_region, response_exclude_runbooks, environment, domain,
+                    eks_audit_logs, eks_audit_logs_regions
+                ): sub_account for sub_account in sub_accounts
+            }
+            for future in concurrent.futures.as_completed(future_to_account):
+                sub_account = future_to_account[future]
+                try:
+                    future.result()
+                except Exception as e:
+                    failures.append((sub_account[0], str(e)))
     else:
         for sub_account in sub_accounts:
-            integrate_sub_account(
-                sub_account, sts_client, graph_client, regions, random_int,
-                custom_tags, regions_to_integrate, control_role, org_account_id,
-                response, response_region, response_exclude_runbooks, environment, domain,
-                eks_audit_logs, eks_audit_logs_regions
-            )
+            try:
+                integrate_sub_account(
+                    sub_account, sts_client, graph_client, regions, random_int,
+                    custom_tags, regions_to_integrate, control_role, org_account_id,
+                    response, response_region, response_exclude_runbooks, environment, domain,
+                    eks_audit_logs, eks_audit_logs_regions
+                )
+            except Exception as e:
+                failures.append((sub_account[0], str(e)))
+
+    if failures:
+        print(color(f"Integration finished with {len(failures)} failure(s):", "red"))
+        for account_id, msg in failures:
+            print(color(f"  {account_id}: {msg}", "red"))
+        raise Exception(f"{len(failures)} account(s) failed to integrate")
 
     print("Integration finished successfully!")
 

--- a/lambda/organization_integration/org_lambda.py
+++ b/lambda/organization_integration/org_lambda.py
@@ -22,6 +22,7 @@ parser.add_argument("--response-region", default="us-east-1", help="Region for r
 parser.add_argument("--response-exclude-runbooks", help="Comma separated list of runbooks to exclude from response stack.")
 parser.add_argument("--eks-audit-logs", action="store_true", help="Enable creation of the EKS audit logs.")
 parser.add_argument("--eks-audit-logs-regions", required=False, help="Comma separated list of regions to enable EKS audit logs.")
+parser.add_argument("--invoke-after-deploy", action="store_true", help="Invoke the Lambda asynchronously after deploy to onboard existing accounts immediately.")
 args = parser.parse_args()
 
 # Apply AWS profile before creating any boto3 clients. If not set, boto3 falls
@@ -137,7 +138,7 @@ def main():
         PolicyArn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
     )
 
-    time.sleep(5)  # Wait for role to propagate
+    time.sleep(10)  # Wait for role + cross-account propagation; 5s was too tight when --invoke-after-deploy hits AssumeRole right after deploy.
 
     # --- Create deployment package (zip) with dependencies ---
     zip_filename = "lambda_deploy.zip"
@@ -203,9 +204,15 @@ def main():
 
     # Create EventBridge rule
     rule_name = "streamsec-organization-newaccount-rule"
+    # CreateAccountResult lands as a service event (async completion of CreateAccount),
+    # not as an API call event. Including both detail-types so the rule matches regardless
+    # of how AWS classifies the record.
     event_pattern = {
         "source": ["aws.organizations"],
-        "detail-type": ["AWS API Call via CloudTrail"],
+        "detail-type": [
+            "AWS API Call via CloudTrail",
+            "AWS Service Event via CloudTrail",
+        ],
         "detail": {"eventName": ["CreateAccountResult"]}
     }
     events_client.put_rule(
@@ -235,6 +242,20 @@ def main():
     )
 
     print("Setup completed successfully!")
+
+    if args.invoke_after_deploy:
+        print("Invoking the Lambda asynchronously to onboard existing accounts...")
+        lambda_client.invoke(
+            FunctionName=function_name,
+            InvocationType='Event',
+            Payload=b'{}',
+        )
+        profile_flag = f" --profile {args.aws_profile}" if args.aws_profile else ""
+        print(
+            "Lambda invoked. Tail logs with:\n"
+            f"  aws logs tail /aws/lambda/{function_name} --follow --since 1m"
+            f" --region us-east-1{profile_flag}"
+        )
 
 def cleanup():
     proceed = input("Do you want to cleanup this script resources? (yes/no): ")

--- a/lambda/organization_integration/org_lambda.py
+++ b/lambda/organization_integration/org_lambda.py
@@ -9,8 +9,10 @@ import tempfile
 
 parser = argparse.ArgumentParser(description="Streamsec Organization Lambda Setup Script")
 parser.add_argument("--environment", required=False, help="The environment name in which the Lambda function will operate.")
-parser.add_argument("--user-name", required=False, help="The username for the environment.")
-parser.add_argument("--password", required=False, help="The password for the environment.")
+parser.add_argument("--user-name", required=False, help="The username for the environment. Ignored if --api-token is provided.")
+parser.add_argument("--password", required=False, help="The password for the environment. Ignored if --api-token is provided.")
+parser.add_argument("--api-token", required=False, help="Stream Security API token. If set, --user-name and --password are not required.")
+parser.add_argument("--aws-profile", required=False, help="AWS profile name to use. If omitted, the default credential chain (env vars, SSO session, instance role, etc.) is used.")
 parser.add_argument("--cleanup", action="store_true", help="Clean up the resources created by the script.")
 parser.add_argument("--accounts", required=False, help="manually specify accounts to integrate.")
 parser.add_argument("--ws-id", required=False, help="The workspace ID.")
@@ -22,28 +24,39 @@ parser.add_argument("--eks-audit-logs", action="store_true", help="Enable creati
 parser.add_argument("--eks-audit-logs-regions", required=False, help="Comma separated list of regions to enable EKS audit logs.")
 args = parser.parse_args()
 
-iam_client = boto3.client('iam')
-sts_client = boto3.client('sts')
-lambda_client = boto3.client('lambda')
-events_client = boto3.client('events')
+# Apply AWS profile before creating any boto3 clients. If not set, boto3 falls
+# back to its default credential chain (env vars, SSO, instance role, etc.).
+if args.aws_profile:
+    os.environ['AWS_PROFILE'] = args.aws_profile
 
-aws_account_id = sts_client.get_caller_identity()['Account']
+
+def _aws_clients():
+    return (
+        boto3.client('iam'),
+        boto3.client('sts'),
+        boto3.client('lambda'),
+        boto3.client('events'),
+    )
+
 
 def main():
     missing_args = []
     if not args.environment:
         missing_args.append("--environment")
-    if not args.user_name:
-        missing_args.append("--user-name")
-    if not args.password:
-        missing_args.append("--password")
+    if not args.api_token:
+        if not args.user_name:
+            missing_args.append("--user-name")
+        if not args.password:
+            missing_args.append("--password")
     if not args.ws_id:
         missing_args.append("--ws-id")
 
     if missing_args:
         print(f"Missing required arguments: {', '.join(missing_args)}")
-        print("These arguments are required unless --cleanup is specified.")
+        print("Either --api-token, or both --user-name and --password, must be provided (unless --cleanup is specified).")
         return
+
+    iam_client, sts_client, lambda_client, events_client = _aws_clients()
     
     # verify the region is us-east-1
     region = boto3.Session().region_name
@@ -147,8 +160,6 @@ def main():
     function_name = "streamsec-organization-lambda"
     env_vars = {
         "ENVIRONMENT": args.environment,
-        "ENVIRONMENT_USER_NAME": args.user_name,
-        "ENVIRONMENT_PASSWORD": args.password,
         "WS_ID": args.ws_id,
         "PARALLEL": "8",
         "CONTROL_ROLE": args.control_role,
@@ -156,6 +167,11 @@ def main():
         "RESPONSE_REGION": args.response_region,
         "EKS_AUDIT_LOGS": str(args.eks_audit_logs).lower(),
     }
+    if args.api_token:
+        env_vars["API_TOKEN"] = args.api_token
+    else:
+        env_vars["ENVIRONMENT_USER_NAME"] = args.user_name
+        env_vars["ENVIRONMENT_PASSWORD"] = args.password
     if args.accounts is not None:
         env_vars["ACCOUNTS"] = args.accounts
         
@@ -228,7 +244,9 @@ def cleanup():
     # try to delete the resources created by the script
     # if resources are not found, ignore the exception
 
-    
+    iam_client, sts_client, lambda_client, events_client = _aws_clients()
+    aws_account_id = sts_client.get_caller_identity()['Account']
+
     try:
         # Delete the Lambda function
         print("Deleting the Lambda function...")

--- a/lambda/organization_integration/org_lambda.py
+++ b/lambda/organization_integration/org_lambda.py
@@ -99,7 +99,7 @@ def main():
                 "Sid": "VisualEditor1",
                 "Effect": "Allow",
                 "Action": "sts:AssumeRole",
-                "Resource": f"arn:aws:iam::*:role/OrganizationAccountAccessRole"
+                "Resource": f"arn:aws:iam::*:role/{args.control_role}"
             }
         ]
     }

--- a/lambda/organization_integration/requirements.txt
+++ b/lambda/organization_integration/requirements.txt
@@ -1,5 +1,4 @@
 boto3~=1.34.109
 botocore~=1.34.109
 requests~=2.31.0
-tqdm~=4.64.1
 termcolor~=1.1.0


### PR DESCRIPTION
## Summary

- **API token auth**: Lambda can authenticate to Stream Security with a long-lived API token (`--api-token` / `API_TOKEN` env var) instead of requiring username + password
- **AWS profile support**: Setup script accepts `--aws-profile` to use a named profile instead of the default credential chain
- **EventBridge fix**: Rule now matches both `AWS API Call via CloudTrail` and `AWS Service Event via CloudTrail` — the old rule never fired because `CreateAccountResult` is a service event
- **Thread-pool exception surfacing**: Worker failures are now collected and reported instead of silently swallowed
- **AssumeRole error handling**: Failures include the account ID and role ARN instead of a raw boto3 traceback
- **IAM policy fix**: `sts:AssumeRole` resource now uses the actual `--control-role` value instead of hardcoded `OrganizationAccountAccessRole`
- **`create_account` return check**: Fails fast if the GraphQL call returns False instead of proceeding to deploy stacks
- **`--invoke-after-deploy` flag**: Optionally invokes the Lambda once after setup to onboard existing accounts immediately
- **Cleanup**: Removed unused `tqdm` dependency, added explicit `import time`

## Prerequisites

- A CloudTrail trail must be active in the management account for EventBridge to receive `CreateAccountResult` events
- Stream Security workspace + API token (or username/password)
- AWS credentials for the management account (SSO, env vars, named profile, or CloudShell)

## Test plan

- [x] Verified API token auth against `app.streamsec.io/graphql` with real token
- [x] Deployed Lambda with `--api-token` + `--aws-profile` — all 4 resources created correctly
- [x] Created CloudTrail trail, then created a new org account
- [x] EventBridge triggered the Lambda — 4 accounts processed in parallel, 3 integrated successfully
- [x] Thread-pool error reporting worked (management account failed with expected CloudFormation AccessDenied)
- [x] Full cleanup verified: Lambda, IAM, EventBridge, CloudTrail trail, S3 bucket, CloudWatch logs all removed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes authentication paths (API token vs. username/password) and the onboarding flow’s error handling/triggering, which can affect whether accounts are integrated or failures surface correctly.
> 
> **Overview**
> Adds API-token authentication for the org integration Lambda (`API_TOKEN` / `--api-token`) alongside the existing username/password path, and updates the setup script to optionally run under a specified AWS profile (`--aws-profile`).
> 
> Improves onboarding reliability by fixing the EventBridge rule to match `CreateAccountResult` service events, optionally invoking the Lambda post-deploy (`--invoke-after-deploy`), and strengthening failure handling (propagating thread-pool exceptions, clearer `AssumeRole` errors, and failing fast when `create_account` fails). Removes the unused `tqdm` dependency and increases the IAM propagation wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad9703cf0f6558001566775688d816fccefcc324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->