### PR TITLE
Fix NoRegionError in org lambda setup script

### DIFF
--- a/lambda/organization_integration/org_lambda.py
+++ b/lambda/organization_integration/org_lambda.py
@@ -33,10 +33,10 @@ if args.aws_profile:
 
 def _aws_clients():
     return (
-        boto3.client('iam'),
-        boto3.client('sts'),
-        boto3.client('lambda'),
-        boto3.client('events'),
+        boto3.client('iam', region_name='us-east-1'),
+        boto3.client('sts', region_name='us-east-1'),
+        boto3.client('lambda', region_name='us-east-1'),
+        boto3.client('events', region_name='us-east-1'),
     )
 
 

--- a/lambda/organization_integration/org_lambda.py
+++ b/lambda/organization_integration/org_lambda.py
@@ -244,6 +244,9 @@ def main():
     print("Setup completed successfully!")
 
     if args.invoke_after_deploy:
+        print("Waiting for Lambda to become active...")
+        waiter = lambda_client.get_waiter('function_active_v2')
+        waiter.wait(FunctionName=function_name)
         print("Invoking the Lambda asynchronously to onboard existing accounts...")
         lambda_client.invoke(
             FunctionName=function_name,


### PR DESCRIPTION
## Summary

- Customers running the setup script from a local terminal without a default AWS region configured hit `botocore.exceptions.NoRegionError` before the script's own us-east-1 validation could run.
- Fix: pass `region_name='us-east-1'` explicitly to all `boto3.client()` calls in `_aws_clients()`, since the script requires us-east-1 anyway.

## Test plan

- [x] Customer reported the issue running from macOS without `AWS_DEFAULT_REGION` set
- [x] Verified the fix resolves the error — boto3 clients now use us-east-1 regardless of local config