### PR TITLE
Add Stream Security token auth + SSO / default-credential support to org integration

### DIFF
--- a/src/python/common/graph_common.py
+++ b/src/python/common/graph_common.py
@@ -127,7 +127,11 @@ class GraphCommon(object):
                 "template_version __typename}vpc_flow_logs{flow_logs_token should_collect_flow_logs __typename} " \
                 "lightlytics_collection_token stack_region account_aliases cost{status details operation " \
                 "template_version role_arn bucket_arn cur_prefix last_timestamp __typename}__typename}}"
-        return self.graph_query(operation, {}, query)['data']['accounts']
+        result = self.graph_query(operation, {}, query)
+        if not isinstance(result, dict):
+            return []
+        accounts = (result.get('data') or {}).get('accounts')
+        return accounts or []
 
     def get_account_response_config(self, cloud_account_id):
         """ Get all accounts.

--- a/src/python/common/graph_common.py
+++ b/src/python/common/graph_common.py
@@ -128,10 +128,13 @@ class GraphCommon(object):
                 "lightlytics_collection_token stack_region account_aliases cost{status details operation " \
                 "template_version role_arn bucket_arn cur_prefix last_timestamp __typename}__typename}}"
         result = self.graph_query(operation, {}, query)
-        if not isinstance(result, dict):
+        accounts = (result.get('data') or {}).get('accounts') if isinstance(result, dict) else None
+        if not accounts:
+            if not getattr(self, "_warned_empty_accounts", False):
+                print(f"Warning: empty/invalid accounts response from {self.url}; treating as no accounts.")
+                self._warned_empty_accounts = True
             return []
-        accounts = (result.get('data') or {}).get('accounts')
-        return accounts or []
+        return accounts
 
     def get_account_response_config(self, cloud_account_id):
         """ Get all accounts.

--- a/src/python/common/graph_common.py
+++ b/src/python/common/graph_common.py
@@ -195,7 +195,16 @@ class GraphCommon(object):
             :returns (str)          - Integration status.
         """
         accounts = self.get_accounts()
-        specific_account = next(account for account in accounts if account["cloud_account_id"] == account_id)
+        if not accounts:
+            raise Exception(
+                f"Stream Security API returned no accounts while checking status for {account_id} "
+                f"(likely a transient/null API response). The integration may have succeeded - "
+                f"verify in the UI and re-run for this account if needed.")
+        specific_account = next(
+            (account for account in accounts if account["cloud_account_id"] == account_id), None)
+        if specific_account is None:
+            raise Exception(
+                f"Account {account_id} was not found in Stream Security while polling its status.")
         return specific_account["status"]
 
     def wait_for_account_connection(self, account, timeout=600):

--- a/src/python/common/graph_common.py
+++ b/src/python/common/graph_common.py
@@ -128,10 +128,13 @@ class GraphCommon(object):
                 "lightlytics_collection_token stack_region account_aliases cost{status details operation " \
                 "template_version role_arn bucket_arn cur_prefix last_timestamp __typename}__typename}}"
         result = self.graph_query(operation, {}, query)
-        accounts = (result.get('data') or {}).get('accounts') if isinstance(result, dict) else None
-        if not accounts:
+        # Treat a null/invalid/errored response as "no accounts" (warn once), but return a
+        # genuinely empty list as-is so an environment with zero integrations isn't flagged.
+        accounts = (result.get('data') or {}).get('accounts') \
+            if isinstance(result, dict) and 'errors' not in result else None
+        if accounts is None or not isinstance(accounts, list):
             if not getattr(self, "_warned_empty_accounts", False):
-                print(f"Warning: empty/invalid accounts response from {self.url}; treating as no accounts.")
+                print(f"Warning: null/invalid accounts response from {self.url}; treating as no accounts.")
                 self._warned_empty_accounts = True
             return []
         return accounts

--- a/src/python/utilities/organization_integration.py
+++ b/src/python/utilities/organization_integration.py
@@ -17,18 +17,18 @@ except ModuleNotFoundError:
 
 
 def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, parallel,
-         ws_id=None, custom_tags=None, regions_to_integrate=None, control_role="OrganizationAccountAccessRole", response=False, response_region="us-east-1", response_exclude_runbooks="", eks_audit_logs=False, eks_audit_logs_regions=None):
-    
+         ws_id=None, custom_tags=None, regions_to_integrate=None, control_role="OrganizationAccountAccessRole", response=False, response_region="us-east-1", response_exclude_runbooks="", eks_audit_logs=False, eks_audit_logs_regions=None, api_token=None):
+
     try:
-        # Check for required parameters
         if not environment_url:
             raise ValueError("The environment URL is required.")
-        if not ll_username:
-            raise ValueError("The StreamSecurity environment user name is required.")
-        if not ll_password:
-            raise ValueError("The StreamSecurity environment password is required.")
-        if not aws_profile_name:
-            raise ValueError("The AWS profile name is required.")
+        if not api_token:
+            if not ll_username:
+                raise ValueError("Either --api_token, or both --environment_user_name and --environment_password, must be provided.")
+            if not ll_password:
+                raise ValueError("Either --api_token, or both --environment_user_name and --environment_password, must be provided.")
+        if api_token and not ws_id:
+            raise ValueError("--ws_id is required when using --api_token.")
     except Exception as e:
         print(color(f"Error: {e}", "red"))
         return
@@ -46,6 +46,9 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
     if regions_to_integrate:
         regions_to_integrate = regions_to_integrate.split(",")
 
+    if eks_audit_logs_regions:
+        eks_audit_logs_regions = eks_audit_logs_regions.split(",")
+
     print(color("Trying to login into Stream Security", "blue"))
     try:
         parsed_url = urlparse(environment_url)
@@ -56,7 +59,10 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
         else:
             raise ValueError("The environment should be a valid URL or a subdomain.")
         print(color(f"Stream Security URL: {ll_url}", "blue"))
-        graph_client = GraphCommon(ll_url, ll_username, ll_password, ws_id)
+        if api_token:
+            graph_client = GraphCommon(ll_url, token=api_token, customer_id=ws_id)
+        else:
+            graph_client = GraphCommon(ll_url, ll_username, ll_password, ws_id)
         print(color("Logged in successfully!", "green"))
     except Exception as e:
         print(color(f"Error: {e}", "red"))
@@ -64,8 +70,11 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
     
     try:
         print(color("Creating Boto3 Session", "blue"))
-        # Set the AWS_PROFILE environment variable
-        os.environ['AWS_PROFILE'] = aws_profile_name
+        if aws_profile_name:
+            os.environ['AWS_PROFILE'] = aws_profile_name
+            print(color(f"Using AWS profile: {aws_profile_name}", "blue"))
+        else:
+            print(color("No AWS profile specified, using default credential chain", "blue"))
         # Set up the Organizations client
         org_client = boto3.client('organizations')
 
@@ -98,24 +107,38 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
         print("Operation canceled.")
         return
 
+    failures = []
     if parallel:
         with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as executor:
-            # Submit tasks to the thread pool
-            results = [executor.submit(
-                integrate_sub_account,
-                environment_url, sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate,
-                control_role, org_account_id, parallel, response, response_region, response_exclude_runbooks, eks_audit_logs, eks_audit_logs_regions
-            ) for sub_account in sub_accounts]
-            # Wait for all tasks to complete
-            concurrent.futures.wait(results)
+            future_to_account = {
+                executor.submit(
+                    integrate_sub_account,
+                    environment_url, sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate,
+                    control_role, org_account_id, parallel, response, response_region, response_exclude_runbooks, eks_audit_logs, eks_audit_logs_regions
+                ): sub_account for sub_account in sub_accounts
+            }
+            for future in concurrent.futures.as_completed(future_to_account):
+                sub_account = future_to_account[future]
+                try:
+                    future.result()
+                except Exception as e:
+                    failures.append((sub_account[0], str(e)))
     else:
         for sub_account in sub_accounts:
-            integrate_sub_account(
-                sub_account, sts_client, graph_client, regions, random_int,
-                custom_tags, regions_to_integrate, control_role, org_account_id, response=response, response_region=response_region, response_exclude_runbooks=response_exclude_runbooks,
-                environment_url=environment_url, eks_audit_logs=eks_audit_logs, eks_audit_logs_regions=eks_audit_logs_regions)
+            try:
+                integrate_sub_account(
+                    environment_url, sub_account, sts_client, graph_client, regions, random_int,
+                    custom_tags, regions_to_integrate, control_role, org_account_id, response=response, response_region=response_region, response_exclude_runbooks=response_exclude_runbooks,
+                    eks_audit_logs=eks_audit_logs, eks_audit_logs_regions=eks_audit_logs_regions)
+            except Exception as e:
+                failures.append((sub_account[0], str(e)))
 
-    print(color("Integration finished successfully!", "green"))
+    if failures:
+        print(color(f"Integration finished with {len(failures)} failure(s):", "red"))
+        for account_id, msg in failures:
+            print(color(f"  {account_id}: {msg}", "red"))
+    else:
+        print(color("Integration finished successfully!", "green"))
 
 
 def integrate_sub_account(
@@ -152,7 +175,8 @@ def integrate_sub_account(
                 
                 # Deploying response stack if enabled
                 response_info = graph_client.get_account_response_config(sub_account_information["cloud_account_id"])
-                if (response_info["remediation"] is None or response_info["remediation"]["status"] is None) and response:
+                remediation = response_info.get("remediation")
+                if (remediation is None or remediation.get("status") is None) and response:
                     deploy_response_stack(
                         environment_url ,sub_account_information, sub_account_session, sub_account, response_region, random_int, custom_tags, response_exclude_runbooks, wait=True)
                 
@@ -204,8 +228,11 @@ def integrate_sub_account(
         # If account is not already integrated to StreamSecurity
         if not ll_integrated:
             print(color(f"Account: {sub_account[0]} | Creating account in StreamSecurity", "blue"))
-            graph_client.create_account(
-                sub_account[0], [sub_account_session.region_name], display_name=sub_account[1])
+            if not graph_client.create_account(
+                    sub_account[0], [sub_account_session.region_name], display_name=sub_account[1]):
+                err_msg = f"Account: {sub_account[0]} | Failed to create account in StreamSecurity"
+                print(color(err_msg, "red"))
+                raise Exception(err_msg)
             print(color(f"Account: {sub_account[0]} | Account created successfully", "green"))
 
         print(color(f"Account: {sub_account[0]} | Fetching relevant account information", "blue"))
@@ -291,12 +318,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "--environment_url", help="The StreamSecurity environment URL", required=True)
     parser.add_argument(
-        "--environment_user_name", help="The StreamSecurity environment user name", required=True)
+        "--api_token", help="Stream Security API token. If set, --environment_user_name and --environment_password are not required.", required=False)
     parser.add_argument(
-        "--environment_password", help="The StreamSecurity environment password", required=True)
+        "--environment_user_name", help="The StreamSecurity environment user name. Ignored if --api_token is provided.", required=False)
     parser.add_argument(
-        "--aws_profile_name", help="The AWS profile with admin permissions for the organization account",
-        default="staging")
+        "--environment_password", help="The StreamSecurity environment password. Ignored if --api_token is provided.", required=False)
+    parser.add_argument(
+        "--aws_profile_name", help="AWS profile name to use. If omitted, the default credential chain (env vars, SSO session, instance role, etc.) is used.",
+        default=None)
     parser.add_argument(
         "--accounts", help="Accounts list to iterate when creating the report (e.g '123123123123,321321321321')",
         required=False)
@@ -327,4 +356,4 @@ if __name__ == "__main__":
          args.aws_profile_name, args.accounts, args.parallel,
          ws_id=args.ws_id, custom_tags=args.custom_tags, regions_to_integrate=args.regions,
          control_role=args.control_role, response=args.response, response_region=args.response_region, response_exclude_runbooks=args.response_exclude_runbooks,
-         eks_audit_logs=args.eks_audit_logs, eks_audit_logs_regions=args.eks_audit_logs_regions)
+         eks_audit_logs=args.eks_audit_logs, eks_audit_logs_regions=args.eks_audit_logs_regions, api_token=args.api_token)

--- a/src/python/utilities/organization_integration.py
+++ b/src/python/utilities/organization_integration.py
@@ -32,7 +32,10 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
     except Exception as e:
         print(color(f"Error: {e}", "red"))
         return
-    
+
+    if not ws_id:
+        print(color("Warning: --ws_id not set; using the first workspace returned by the API.", "yellow"))
+
     # Setting up variables
     random_int = random.randint(1000000, 9999999)
     if accounts:

--- a/src/python/utilities/organization_integration.py
+++ b/src/python/utilities/organization_integration.py
@@ -22,13 +22,14 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
     try:
         if not environment_url:
             raise ValueError("The environment URL is required.")
-        if not api_token:
+        if api_token:
+            if not ws_id:
+                raise ValueError("--ws_id is required when using --api_token.")
+        else:
             if not ll_username:
-                raise ValueError("Either --api_token, or both --environment_user_name and --environment_password, must be provided.")
+                raise ValueError("--environment_user_name is required (or use --api_token instead).")
             if not ll_password:
-                raise ValueError("Either --api_token, or both --environment_user_name and --environment_password, must be provided.")
-        if api_token and not ws_id:
-            raise ValueError("--ws_id is required when using --api_token.")
+                raise ValueError("--environment_password is required (or use --api_token instead).")
     except Exception as e:
         print(color(f"Error: {e}", "red"))
         return
@@ -113,6 +114,9 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
     failures = []
     if parallel:
         with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as executor:
+            # `parallel` is passed positionally on purpose: integrate_sub_account uses
+            # `not parallel` to skip per-account blocking waits in parallel mode (the
+            # sequential path below omits it -> defaults to False -> waits per account).
             future_to_account = {
                 executor.submit(
                     integrate_sub_account,
@@ -122,19 +126,21 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
             }
             for future in concurrent.futures.as_completed(future_to_account):
                 sub_account = future_to_account[future]
+                account_id = sub_account[0]
                 try:
                     future.result()
                 except Exception as e:
-                    failures.append((sub_account[0], str(e)))
+                    failures.append((account_id, str(e)))
     else:
         for sub_account in sub_accounts:
+            account_id = sub_account[0]
             try:
                 integrate_sub_account(
                     environment_url, sub_account, sts_client, graph_client, regions, random_int,
                     custom_tags, regions_to_integrate, control_role, org_account_id, response=response, response_region=response_region, response_exclude_runbooks=response_exclude_runbooks,
                     eks_audit_logs=eks_audit_logs, eks_audit_logs_regions=eks_audit_logs_regions)
             except Exception as e:
-                failures.append((sub_account[0], str(e)))
+                failures.append((account_id, str(e)))
 
     if failures:
         print(color(f"Integration finished with {len(failures)} failure(s):", "red"))

--- a/src/python/utilities/organization_integration.py
+++ b/src/python/utilities/organization_integration.py
@@ -48,10 +48,10 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
 
     # Prepare regions if provided
     if regions_to_integrate:
-        regions_to_integrate = regions_to_integrate.split(",")
+        regions_to_integrate = [r.strip() for r in regions_to_integrate.split(",") if r.strip()]
 
     if eks_audit_logs_regions:
-        eks_audit_logs_regions = eks_audit_logs_regions.split(",")
+        eks_audit_logs_regions = [r.strip() for r in eks_audit_logs_regions.split(",") if r.strip()]
 
     print(color("Trying to login into Stream Security", "blue"))
     try:


### PR DESCRIPTION
## Goal

Enable **SSO-based usage** of `src/python/utilities/organization_integration.py`. Today the script forces username/password auth and a named AWS profile. This PR lets you run it with:

- a **Stream Security API token** instead of username/password, and
- the **default AWS credential chain** (AWS SSO session, env vars, instance role, …) instead of a mandatory `--aws_profile_name`.

This brings the script in line with the patterns already used in `lambda/organization_integration/` and `src/python/utilities/update_all_stacks.py`.

With the new flow you only need: `--environment_url`, `--api_token`, `--ws_id` (and AWS creds from your SSO session):

```bash
python src/python/utilities/organization_integration.py \
  --environment_url https://<env>.streamsec.io/ \
  --api_token <TOKEN> \
  --ws_id <WORKSPACE_ID> \
  --parallel 10
```

## Behavior change (intentional)

`--aws_profile_name` is now **optional** (default `None`) instead of defaulting to `"staging"` — this is the point of the PR: with no profile, the script uses the default AWS credential chain (SSO/env/instance role). If you previously relied on the implicit `staging` default, pass `--aws_profile_name staging` explicitly.

## Changes

### Feature — SSO support
- `--api_token`: authenticate via token; `--environment_user_name`/`--environment_password` are no longer required when a token is supplied.
- `--aws_profile_name` optional (default `None`); when omitted the default credential chain is used (prints `No AWS profile specified, using default credential chain`).
- `--ws_id` is required with token auth; a warning is printed when it is omitted on the username/password path (avoids silently landing in the first workspace).

### Minor fixes (found while testing)
- Split `--eks_audit_logs_regions` on commas (was iterated char-by-char).
- Collect per-account failures in the **parallel** path (`as_completed` + `future.result()`); previously worker exceptions were swallowed.
- Fix the sequential call's argument order (`environment_url` was passed both positionally and by keyword → `TypeError`).
- Honest completion report: prints `Integration finished with N failure(s):` instead of always claiming success.
- `get_account_response_config` access via `.get("remediation")` to avoid a `KeyError`.
- Raise if `create_account` returns `False` instead of silently continuing.
- Clearer error in `get_account_status` when the API returns a null/empty response.
- Harden `get_accounts()` to always return a list (transient null/error responses no longer surface as `'NoneType' object is not iterable`); one-shot warning when this happens.

### Review feedback
- Restructured credential validation into a clean `if api_token / else` block, with distinct messages for missing username vs. password.
- Named `account_id` variable in the failure-collection loops.

## Testing
- **Offline suite** (unittest.mock): 25/25 — validation rules, token vs user/pass selection, ws_id warning, eks split, parallel + sequential failure collection, create-failure, missing-remediation, get_accounts hardening, clear status errors.
- **Live end-to-end** against a stage environment: token auth + no AWS profile + `--parallel 10` across a 2-account org — both accounts created, init + collection stacks deployed across regions, `Integration finished successfully!`.