### PR TITLE
Add lambda-only delete mode to organization_delete_integration

### DIFF
--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -3,6 +3,7 @@ import datetime
 import time
 from termcolor import colored as color
 import os
+from botocore.config import Config
 
 def get_all_accounts(org_client):
     list_accounts = []
@@ -378,3 +379,42 @@ def format_plan_lines(results):
     and easy diffing/grepping of the written plan file."""
     return [f"{r['account']} | {r['region']} | {r['function']}"
             for r in sorted(results, key=lambda r: (r["account"], r["region"], r["function"]))]
+
+
+LAMBDA_CLIENT_CONFIG = Config(
+    connect_timeout=15,
+    read_timeout=60,
+    retries={"max_attempts": 10, "mode": "adaptive"},
+)
+
+
+def scan_lambdas_in_region(sub_account_session, region, pattern):
+    """List Lambda functions in a region, keep those whose name matches pattern,
+    and split them into (to_delete, skipped_cfn). A function tagged as
+    CloudFormation-managed goes to skipped_cfn with its owning stack name; it is
+    never deleted. list_tags is called only for name-matched functions."""
+    client = sub_account_session.client("lambda", region_name=region, config=LAMBDA_CLIENT_CONFIG)
+    to_delete, skipped_cfn = [], []
+    for page in client.get_paginator("list_functions").paginate():
+        for fn in page["Functions"]:
+            name = fn["FunctionName"]
+            if not lambda_name_matches(name, pattern):
+                continue
+            tags = client.list_tags(Resource=fn["FunctionArn"]).get("Tags", {})
+            if is_cfn_managed(tags):
+                skipped_cfn.append(
+                    {"region": region, "function": name, "stack": tags[CFN_STACK_NAME_TAG]})
+            else:
+                to_delete.append({"region": region, "function": name})
+    return to_delete, skipped_cfn
+
+
+def delete_lambda_function(sub_account_session, region, function_name):
+    """Delete a Lambda function. Returns 'deleted', or 'already gone' if it was
+    already removed between the scan and now. Other errors propagate to the caller."""
+    client = sub_account_session.client("lambda", region_name=region, config=LAMBDA_CLIENT_CONFIG)
+    try:
+        client.delete_function(FunctionName=function_name)
+        return "deleted"
+    except client.exceptions.ResourceNotFoundException:
+        return "already gone"

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -441,3 +441,51 @@ def confirm_deletion(total, account_count, isatty_fn, input_fn):
         return True
     print(color("Confirmation did not match 'delete' — nothing was deleted.", "yellow"))
     return False
+
+
+def write_plan_file(results, path):
+    """Write the full delete plan (one 'account | region | function' per line) to
+    path so it can be grepped, diffed, shared, and kept as an audit record."""
+    with open(path, "w") as f:
+        f.write("\n".join(format_plan_lines(results)) + "\n")
+
+
+def print_lambda_plan(results, skipped_cfn):
+    """Print the delete plan: a per-account roll-up (biggest blast radius first),
+    the grand total, the full flat table, and the CFN-managed functions skipped."""
+    rollup = build_account_rollup(results)
+    print(color("Lambda functions to delete (per account):", "blue"))
+    for account_id, name, count in rollup:
+        print(f"  {account_id} ({name})  {count} functions")
+    print(color(
+        f"Total: {len(results)} functions across {len(rollup)} accounts", "blue"))
+    if results:
+        print(color("Full list:", "blue"))
+        for line in format_plan_lines(results):
+            print(f"  {line}")
+    if skipped_cfn:
+        print(color(
+            f"Skipped {len(skipped_cfn)} CloudFormation-managed function(s) "
+            f"(not deleted):", "yellow"))
+        for s in sorted(skipped_cfn, key=lambda x: (x["account"], x["region"], x["function"])):
+            print(f"  {s['account']} | {s['region']} | {s['function']} "
+                  f"(stack: {s['stack']})")
+
+
+def print_lambda_summary(deleted, already_gone, failed, skipped_cfn, assume_role_failures):
+    """Print end-of-run counts with per-item detail for failures and an explicit
+    list of accounts where assume-role failed (copy them into --accounts for a
+    re-run). Returns the number of items needing attention, for the exit code."""
+    print(color("=" * 60, "blue"))
+    print(color(
+        f"Run summary: {len(deleted)} deleted | {len(already_gone)} already gone | "
+        f"{len(failed)} failed | {len(skipped_cfn)} skipped (CFN-managed) | "
+        f"{len(assume_role_failures)} accounts unreachable (assume-role failed)", "blue"))
+    for r in failed:
+        print(color(
+            f"  FAILED | account {r['account']} | {r['region']} | {r['function']} | "
+            f"{r['reason']}", "red"))
+    for account_id, name, err in assume_role_failures:
+        print(color(
+            f"  ASSUME-ROLE FAILED | account {account_id} ({name}) | {err}", "red"))
+    return len(failed) + len(assume_role_failures)

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -333,3 +333,27 @@ def filter_ll_stacks_from_url(sub_account_session, region, ll_url, return_only_n
             return ll_stacks_to_return
     except Exception:
         return []
+
+
+CFN_STACK_NAME_TAG = "aws:cloudformation:stack-name"
+LAMBDA_MIN_PATTERN_LEN = 3
+
+
+def validate_lambda_pattern(pattern):
+    """Return the stripped pattern, or raise ValueError if it is missing or
+    shorter than LAMBDA_MIN_PATTERN_LEN characters (guards against a typo like
+    's' matching hundreds of functions)."""
+    if pattern is None or len(pattern.strip()) < LAMBDA_MIN_PATTERN_LEN:
+        raise ValueError(
+            f"--lambda_name_contains must be at least {LAMBDA_MIN_PATTERN_LEN} characters")
+    return pattern.strip()
+
+
+def lambda_name_matches(function_name, pattern):
+    """Case-insensitive substring match of pattern within function_name."""
+    return pattern.lower() in function_name.lower()
+
+
+def is_cfn_managed(tags):
+    """True if the Lambda's tags mark it as CloudFormation-managed."""
+    return CFN_STACK_NAME_TAG in (tags or {})

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -481,10 +481,20 @@ def print_lambda_plan(results, skipped_cfn):
                   f"(stack: {s['stack']})")
 
 
+def format_assume_role_failure_lines(assume_role_failures):
+    """Single source of the per-account 'ASSUME-ROLE FAILED' line format, shared
+    by print_lambda_summary and the CF-mode summary so the two cannot drift."""
+    return [f"  ASSUME-ROLE FAILED | account {account_id} ({name}) | {err}"
+            for account_id, name, err in assume_role_failures]
+
+
 def print_lambda_summary(deleted, already_gone, failed, skipped_cfn, assume_role_failures):
     """Print end-of-run counts with per-item detail for failures and an explicit
     list of accounts where assume-role failed (copy them into --accounts for a
-    re-run). Returns the number of items needing attention, for the exit code."""
+    re-run). Returns len(failed) — the count of actual operation failures that
+    should drive a non-zero exit. Unreachable accounts are reported but do NOT
+    affect the exit code (an account we merely couldn't reach is a reported gap,
+    not an operation failure)."""
     print(color("=" * 60, "blue"))
     print(color(
         f"Run summary: {len(deleted)} deleted | {len(already_gone)} already gone | "
@@ -494,7 +504,6 @@ def print_lambda_summary(deleted, already_gone, failed, skipped_cfn, assume_role
         print(color(
             f"  FAILED | account {r['account']} | {r['region']} | {r['function']} | "
             f"{r['reason']}", "red"))
-    for account_id, name, err in assume_role_failures:
-        print(color(
-            f"  ASSUME-ROLE FAILED | account {account_id} ({name}) | {err}", "red"))
-    return len(failed) + len(assume_role_failures)
+    for line in format_assume_role_failure_lines(assume_role_failures):
+        print(color(line, "yellow"))
+    return len(failed)

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -418,3 +418,26 @@ def delete_lambda_function(sub_account_session, region, function_name):
         return "deleted"
     except client.exceptions.ResourceNotFoundException:
         return "already gone"
+
+
+def confirm_deletion(total, account_count, isatty_fn, input_fn):
+    """Interactive safety gate. Returns True only on an interactive terminal when
+    the operator types exactly 'delete'. On a non-TTY (nohup/pipe/CI) it refuses
+    instead of blocking forever on input(); EOF/Ctrl+C also abort. isatty_fn and
+    input_fn are injected so this is unit-testable."""
+    if not isatty_fn():
+        print(color(
+            "No interactive terminal detected — refusing to delete. "
+            "Run interactively, or use --just_print to preview.", "red"))
+        return False
+    try:
+        answer = input_fn(
+            f"About to delete {total} lambda functions across {account_count} accounts. "
+            f"Type 'delete' to proceed: ")
+    except (EOFError, KeyboardInterrupt):
+        print(color("\nAborted — nothing was deleted.", "yellow"))
+        return False
+    if answer.strip() == "delete":
+        return True
+    print(color("Confirmation did not match 'delete' — nothing was deleted.", "yellow"))
+    return False

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -357,3 +357,24 @@ def lambda_name_matches(function_name, pattern):
 def is_cfn_managed(tags):
     """True if the Lambda's tags mark it as CloudFormation-managed."""
     return CFN_STACK_NAME_TAG in (tags or {})
+
+
+def build_account_rollup(results):
+    """Group delete-plan results by account into (account_id, account_name, count)
+    tuples, sorted by count descending then account id, so the accounts losing the
+    most functions appear first."""
+    counts = {}
+    names = {}
+    for r in results:
+        counts[r["account"]] = counts.get(r["account"], 0) + 1
+        names[r["account"]] = r.get("name", "")
+    rollup = [(acc, names[acc], cnt) for acc, cnt in counts.items()]
+    rollup.sort(key=lambda t: (-t[2], t[0]))
+    return rollup
+
+
+def format_plan_lines(results):
+    """One 'account | region | function' line per result, sorted for stable output
+    and easy diffing/grepping of the written plan file."""
+    return [f"{r['account']} | {r['region']} | {r['function']}"
+            for r in sorted(results, key=lambda r: (r["account"], r["region"], r["function"]))]

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -390,23 +390,32 @@ LAMBDA_CLIENT_CONFIG = Config(
 
 def scan_lambdas_in_region(sub_account_session, region, pattern):
     """List Lambda functions in a region, keep those whose name matches pattern,
-    and split them into (to_delete, skipped_cfn). A function tagged as
-    CloudFormation-managed goes to skipped_cfn with its owning stack name; it is
-    never deleted. list_tags is called only for name-matched functions."""
+    and split them into (to_delete, skipped_cfn, scan_errors). A function tagged
+    as CloudFormation-managed goes to skipped_cfn with its owning stack name; it
+    is never deleted. list_tags is called only for name-matched functions, and a
+    per-function tag failure never aborts the region scan: the function is left
+    out of to_delete (we can't confirm it isn't CFN-managed, so deleting it would
+    be unsafe) and recorded in scan_errors so the operator sees the gap."""
     client = sub_account_session.client("lambda", region_name=region, config=LAMBDA_CLIENT_CONFIG)
-    to_delete, skipped_cfn = [], []
+    to_delete, skipped_cfn, scan_errors = [], [], []
     for page in client.get_paginator("list_functions").paginate():
         for fn in page["Functions"]:
             name = fn["FunctionName"]
             if not lambda_name_matches(name, pattern):
                 continue
-            tags = client.list_tags(Resource=fn["FunctionArn"]).get("Tags", {})
+            try:
+                tags = client.list_tags(Resource=fn["FunctionArn"]).get("Tags", {})
+            except Exception as e:
+                scan_errors.append(
+                    {"region": region, "function": name,
+                     "reason": f"could not read tags, left out of plan: {str(e)[:150]}"})
+                continue
             if is_cfn_managed(tags):
                 skipped_cfn.append(
                     {"region": region, "function": name, "stack": tags[CFN_STACK_NAME_TAG]})
             else:
                 to_delete.append({"region": region, "function": name})
-    return to_delete, skipped_cfn
+    return to_delete, skipped_cfn, scan_errors
 
 
 def delete_lambda_function(sub_account_session, region, function_name):

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -491,10 +491,11 @@ def format_assume_role_failure_lines(assume_role_failures):
 def print_lambda_summary(deleted, already_gone, failed, skipped_cfn, assume_role_failures):
     """Print end-of-run counts with per-item detail for failures and an explicit
     list of accounts where assume-role failed (copy them into --accounts for a
-    re-run). Returns len(failed) — the count of actual operation failures that
-    should drive a non-zero exit. Unreachable accounts are reported but do NOT
-    affect the exit code (an account we merely couldn't reach is a reported gap,
-    not an operation failure)."""
+    re-run). Returns len(failed) — the count of items that should drive a
+    non-zero exit. Callers deliberately include scan gaps (regions/functions
+    whose state couldn't be read) in `failed`, so those count too. Unreachable
+    accounts are reported separately and do NOT affect the exit code (an account
+    we merely couldn't reach is a reported gap, not an operation failure)."""
     print(color("=" * 60, "blue"))
     print(color(
         f"Run summary: {len(deleted)} deleted | {len(already_gone)} already gone | "

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -329,8 +329,10 @@ def _run_cf_mode(sub_accounts, sts_client, management_account_id, regions,
         for line in format_assume_role_failure_lines(assume_role_failures):
             print(color(line, "yellow"))
     # Unreachable accounts are reported but do not fail the exit code (they are a
-    # gap, not an operation failure). The underlying stack-delete helper does not
-    # surface per-stack failures, so CF mode has no operation-failure count.
+    # gap, not an operation failure). CF mode does not compute a per-stack failure
+    # count: delete_stacks_in_all_regions only *initiates* deletion (asynchronous,
+    # no waiter), so stack-deletion outcomes are never observed here; a failure to
+    # initiate a delete propagates as an exception rather than a counted failure.
     return 0
 
 

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -214,17 +214,26 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
 
 def _run_cf_mode(sub_accounts, sts_client, management_account_id, regions,
                  just_print, force_delete_failed, stack_name_contains):
+    assume_role_failures = []
     for sub_account in sub_accounts:
         try:
             session = _session_for_account(sub_account, sts_client, management_account_id)
         except Exception as e:
             print(color(f"Account: {sub_account[0]} | Can't assume role, skipping. "
                         f"Error: {e}", "red"))
+            assume_role_failures.append((sub_account[0], sub_account[1], str(e)))
             continue
         print(color(f"Account: {sub_account[0]} | Session initialized", "green"))
         delete_stacks_in_all_regions(sub_account, session, regions, just_print,
                                      force_delete_failed, stack_name_contains)
-    return 0
+    if assume_role_failures:
+        print(color("=" * 60, "blue"))
+        print(color(f"{len(assume_role_failures)} account(s) unreachable (assume-role failed):", "red"))
+        for account_id, name, err in assume_role_failures:
+            print(color(f"  ASSUME-ROLE FAILED | account {account_id} ({name}) | {err}", "red"))
+    # Non-zero when any account could not be reached, so scripted/CI callers see
+    # a partial run as a failure (mirrors lambda mode's exit-code contract).
+    return len(assume_role_failures)
 
 
 def main(accounts, aws_profile_name, regions=None, just_print=False,

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -1,87 +1,251 @@
 import argparse
-import boto3
+import concurrent.futures
 import os
 import sys
+import time
 
 # Add the project root directory to the Python path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
 try:
     from src.python.common.boto_common import *
-    from src.python.common.graph_common import GraphCommon
 except ModuleNotFoundError:
     sys.path.append("../../..")
     from src.python.common.boto_common import *
-    from src.python.common.graph_common import GraphCommon
+
+import boto3
 
 
-def main(accounts, aws_profile_name, just_print=False, force_delete_failed=False, stack_name_contains=None):
-    if accounts:
-        accounts = accounts.replace(" ", "").split(",")
+class _DeleteIntegrationParser(argparse.ArgumentParser):
+    """Parser that rejects mixing lambda-only mode with the stack-only flags,
+    regardless of the order the flags appear in."""
+    def parse_args(self, args=None, namespace=None):
+        ns = super().parse_args(args, namespace)
+        if ns.lambda_name_contains and (ns.force_delete_failed or ns.stack_name_contains):
+            self.error(
+                "--lambda_name_contains cannot be combined with --force_delete_failed "
+                "or --stack_name_contains (lambda-only mode does not touch stacks).")
+        return ns
 
-    print(color("Creating Boto3 Session", "blue"))
-    # Set the AWS_PROFILE environment variable
-    os.environ['AWS_PROFILE'] = aws_profile_name
 
-    # Set up the Organizations client
+def build_arg_parser():
+    parser = _DeleteIntegrationParser(
+        description="Delete Stream Security integration from organization accounts. "
+                    "Default mode deletes the CloudFormation stacks (which removes the "
+                    "integration). Lambda-only mode (--lambda_name_contains) deletes only "
+                    "matching Lambda functions and does NOT remove the integration.")
+    parser.add_argument(
+        "--accounts", help="Account IDs to target, e.g. '111111111111,222222222222' "
+        "(default: all ACTIVE org accounts)", required=False)
+    parser.add_argument(
+        "--regions", help="Regions to target, e.g. 'us-east-1,eu-west-1' "
+        "(default: all enabled regions)", required=False)
+    parser.add_argument(
+        "--aws_profile_name", help="AWS profile with admin permissions on the org account. "
+        "Omit to use the default credential chain / SSO.", default=None)
+    parser.add_argument(
+        "--just_print", action="store_true",
+        help="Dry run - list what would be deleted, delete nothing")
+    # Stack-only flags (CF mode)
+    parser.add_argument(
+        "--force_delete_failed", action="store_true",
+        help="CF mode only: target DELETE_FAILED stacks with FORCE_DELETE_STACK")
+    parser.add_argument(
+        "--stack_name_contains",
+        help="CF mode only: filter stacks by name (case-insensitive)", required=False)
+    # Lambda-only mode
+    parser.add_argument(
+        "--lambda_name_contains",
+        help="LAMBDA-ONLY MODE: delete only Lambda functions whose name contains this "
+        "string (case-insensitive, min 3 chars). Does NOT touch CloudFormation stacks and "
+        "does NOT remove the Stream Security integration. Mutually exclusive with the "
+        "stack-only flags.", required=False)
+    return parser
+
+
+def _session_for_account(sub_account, sts_client, management_account_id):
+    """Return a boto3 Session for the account, or raise on assume-role failure.
+    The management account uses the current session (no assume-role)."""
+    if sub_account[0] == management_account_id:
+        return boto3.Session()
+    assumed_role = sts_client.assume_role(
+        RoleArn=f'arn:aws:iam::{sub_account[0]}:role/OrganizationAccountAccessRole',
+        RoleSessionName='MySessionName')
+    return boto3.Session(
+        aws_access_key_id=assumed_role['Credentials']['AccessKeyId'],
+        aws_secret_access_key=assumed_role['Credentials']['SecretAccessKey'],
+        aws_session_token=assumed_role['Credentials']['SessionToken'])
+
+
+def _scan_account_lambdas(sub_account, session, regions, pattern):
+    """Scan all regions of one account in parallel; return (to_delete, skipped)
+    with account id+name stamped on each result dict."""
+    to_delete, skipped = [], []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        future_to_region = {
+            executor.submit(scan_lambdas_in_region, session, region, pattern): region
+            for region in regions}
+        for future in concurrent.futures.as_completed(future_to_region):
+            region = future_to_region[future]
+            try:
+                region_delete, region_skipped = future.result()
+            except Exception as e:
+                print(color(f"Account: {sub_account[0]} | Failed to scan region "
+                            f"{region}: {e}", "red"))
+                continue
+            for d in region_delete:
+                d.update({"account": sub_account[0], "name": sub_account[1]})
+                to_delete.append(d)
+            for s in region_skipped:
+                s.update({"account": sub_account[0], "name": sub_account[1]})
+                skipped.append(s)
+    return to_delete, skipped
+
+
+def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
+                     pattern, just_print):
+    pattern = validate_lambda_pattern(pattern)
+    print(color(
+        "LAMBDA-ONLY MODE: only Lambda functions will be deleted. CloudFormation "
+        "stacks are NOT touched — to remove the Stream Security integration itself, "
+        "run without --lambda_name_contains.", "yellow"))
+
+    all_to_delete, all_skipped, assume_role_failures = [], [], []
+
+    # Scan phase
+    for sub_account in sub_accounts:
+        try:
+            session = _session_for_account(sub_account, sts_client, management_account_id)
+        except Exception as e:
+            print(color(f"Account: {sub_account[0]} | Can't assume role, skipping. "
+                        f"Error: {e}", "red"))
+            assume_role_failures.append((sub_account[0], sub_account[1], str(e)))
+            continue
+        print(color(f"Account: {sub_account[0]} | Scanning {len(regions)} regions", "blue"))
+        to_delete, skipped = _scan_account_lambdas(sub_account, session, regions, pattern)
+        all_to_delete.extend(to_delete)
+        all_skipped.extend(skipped)
+
+    # Listing + plan file
+    print_lambda_plan(all_to_delete, all_skipped)
+    plan_path = os.path.join(
+        os.getcwd(), f"lambda_delete_plan_{time.strftime('%Y%m%d-%H%M%S')}.txt")
+    if all_to_delete:
+        write_plan_file(all_to_delete, plan_path)
+        print(color(f"Full plan written to: {plan_path}", "blue"))
+
+    if just_print:
+        print(color("Dry run (--just_print) - nothing deleted.", "green"))
+        return 0
+    if not all_to_delete:
+        print(color("No matching lambda functions found - nothing to delete.", "green"))
+        return 0
+
+    account_count = len({d["account"] for d in all_to_delete})
+    if not confirm_deletion(len(all_to_delete), account_count, sys.stdin.isatty, input):
+        return 0
+
+    # Delete phase - re-assume roles fresh (the scan can outlive 1h STS creds)
+    deleted, already_gone, failed = [], [], []
+    by_account = {}
+    for d in all_to_delete:
+        by_account.setdefault((d["account"], d["name"]), []).append(d)
+
+    try:
+        for (account_id, name), items in by_account.items():
+            sub_account = (account_id, name)
+            try:
+                session = _session_for_account(sub_account, sts_client, management_account_id)
+            except Exception as e:
+                print(color(f"Account: {account_id} | Can't assume role for delete, "
+                            f"skipping. Error: {e}", "red"))
+                assume_role_failures.append((account_id, name, str(e)))
+                continue
+            with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+                future_to_item = {
+                    executor.submit(delete_lambda_function, session, it["region"],
+                                    it["function"]): it for it in items}
+                for future in concurrent.futures.as_completed(future_to_item):
+                    it = future_to_item[future]
+                    try:
+                        outcome = future.result()
+                        if outcome == "already gone":
+                            already_gone.append(it)
+                        else:
+                            deleted.append(it)
+                            print(color(f"Account: {account_id} | Deleted "
+                                        f"{it['function']} ({it['region']})", "green"))
+                    except Exception as e:
+                        it2 = dict(it, reason=str(e)[:200])
+                        failed.append(it2)
+                        print(color(f"Account: {account_id} | Failed to delete "
+                                    f"{it['function']} ({it['region']}): {e}", "red"))
+    except KeyboardInterrupt:
+        print(color("\nInterrupted - stopping. Summary of work done so far:", "yellow"))
+
+    return print_lambda_summary(deleted, already_gone, failed, all_skipped,
+                                assume_role_failures)
+
+
+def _run_cf_mode(sub_accounts, sts_client, management_account_id, regions,
+                 just_print, force_delete_failed, stack_name_contains):
+    for sub_account in sub_accounts:
+        try:
+            session = _session_for_account(sub_account, sts_client, management_account_id)
+        except Exception as e:
+            print(color(f"Account: {sub_account[0]} | Can't assume role, skipping. "
+                        f"Error: {e}", "red"))
+            continue
+        print(color(f"Account: {sub_account[0]} | Session initialized", "green"))
+        delete_stacks_in_all_regions(sub_account, session, regions, just_print,
+                                     force_delete_failed, stack_name_contains)
+    return 0
+
+
+def main(accounts, aws_profile_name, regions=None, just_print=False,
+         force_delete_failed=False, stack_name_contains=None, lambda_name_contains=None):
+    # Adaptive retries for every client created below (both modes)
+    os.environ["AWS_RETRY_MODE"] = "adaptive"
+    os.environ["AWS_MAX_ATTEMPTS"] = "10"
+
+    if aws_profile_name:
+        os.environ['AWS_PROFILE'] = aws_profile_name
+        print(color(f"Using AWS profile: {aws_profile_name}", "blue"))
+    else:
+        print(color("No AWS profile specified - using default credential chain", "blue"))
+
+    account_filter = accounts.replace(" ", "").split(",") if accounts else None
+
     org_client = boto3.client('organizations', region_name='us-east-1')
-
-    # Set up the STS client
     sts_client = boto3.client('sts', region_name='us-east-1')
 
-    # Get all activated regions from Org account
-    regions = [region['RegionName'] for region in boto3.client('ec2', region_name='us-east-1').describe_regions()['Regions']]
+    if regions:
+        regions = regions.replace(" ", "").split(",")
+    else:
+        regions = [r['RegionName'] for r in
+                   boto3.client('ec2', region_name='us-east-1').describe_regions()['Regions']]
+    print(color(f"Targeting {len(regions)} region(s)", "blue"))
 
     print("Fetching all accounts connected to the organization")
     list_accounts = get_all_accounts(org_client)
-
-    # Getting only the account IDs of the active AWS accounts
+    management_account_id = org_client.describe_organization()['Organization']['MasterAccountId']
     sub_accounts = [(a["Id"], a["Name"]) for a in list_accounts if a["Status"] == "ACTIVE"]
-    print(f"Found {len(sub_accounts)} accounts")
+    if account_filter:
+        sub_accounts = [sa for sa in sub_accounts if sa[0] in account_filter]
+    print(color(f"Accounts to process: {[sa[0] for sa in sub_accounts]}", "blue"))
 
-    if accounts:
-        sub_accounts = [sa for sa in sub_accounts if sa[0] in accounts]
-
-    print(color(f"Accounts to-be deleted: {[sa[0] for sa in sub_accounts]}", "blue"))
-
-    for sub_account in sub_accounts:
-        try:
-            # Assume the role in the sub_account[0]
-            assumed_role = sts_client.assume_role(
-                RoleArn=f'arn:aws:iam::{sub_account[0]}:role/OrganizationAccountAccessRole',
-                RoleSessionName='MySessionName'
-            )
-        except Exception as e:
-            print(color(f"Account: {sub_account[0]} | Can't assume role, skipping. Error: {e}", "red"))
-            continue
-
-        print(color(f"Account: {sub_account[0]} | Initializing Boto session", "blue"))
-        sub_account_session = boto3.Session(
-            aws_access_key_id=assumed_role['Credentials']['AccessKeyId'],
-            aws_secret_access_key=assumed_role['Credentials']['SecretAccessKey'],
-            aws_session_token=assumed_role['Credentials']['SessionToken']
-        )
-        print(color(f"Account: {sub_account[0]} | Session initialized successfully", "green"))
-
-        delete_stacks_in_all_regions(sub_account, sub_account_session, regions, just_print, force_delete_failed, stack_name_contains)
+    if lambda_name_contains:
+        return _run_lambda_mode(sub_accounts, sts_client, management_account_id,
+                                regions, lambda_name_contains, just_print)
+    return _run_cf_mode(sub_accounts, sts_client, management_account_id, regions,
+                        just_print, force_delete_failed, stack_name_contains)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description='This script will delete all Lightlytics/StreamSecurity stacks from organization accounts.')
-    parser.add_argument(
-        "--accounts", help="Accounts list to iterate (e.g '123123123123,321321321321')",
-        required=False)
-    parser.add_argument(
-        "--aws_profile_name", help="The AWS profile with admin permissions for the organization account",
-        default="staging")
-    parser.add_argument(
-        "--just_print", action="store_true", help="Dry run - only print stacks that would be deleted")
-    parser.add_argument(
-        "--force_delete_failed", action="store_true",
-        help="Only target DELETE_FAILED stacks and use FORCE_DELETE_STACK mode")
-    parser.add_argument(
-        "--stack_name_contains", help="Filter stacks by custom name pattern (case-insensitive). "
-        "When provided, replaces the default Lightlytics/lightlytics filter.",
-        required=False)
+    parser = build_arg_parser()
     args = parser.parse_args()
-    main(args.accounts, args.aws_profile_name, just_print=args.just_print, force_delete_failed=args.force_delete_failed, stack_name_contains=args.stack_name_contains)
+    exit_code = main(
+        args.accounts, args.aws_profile_name, regions=args.regions,
+        just_print=args.just_print, force_delete_failed=args.force_delete_failed,
+        stack_name_contains=args.stack_name_contains,
+        lambda_name_contains=args.lambda_name_contains)
+    sys.exit(1 if exit_code else 0)

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -133,31 +133,38 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
     all_to_delete, all_skipped, all_scan_errors, assume_role_failures = [], [], [], []
 
     # Scan phase
-    for sub_account in sub_accounts:
-        try:
-            session = _session_for_account(sub_account, sts_client, management_account_id)
-        except Exception as e:
-            print(color(f"Account: {sub_account[0]} | Can't assume role, skipping. "
-                        f"Error: {e}", "red"))
-            assume_role_failures.append((sub_account[0], sub_account[1], str(e)))
-            continue
-        print(color(f"Account: {sub_account[0]} | Scanning {len(regions)} regions", "blue"))
-        try:
-            to_delete, skipped, scan_errors = _scan_account_lambdas(
-                sub_account, session, regions, pattern)
-        except Exception as e:
-            # One account's unexpected scan error must not discard every other
-            # account's results — record it as a gap and carry on.
-            print(color(f"Account: {sub_account[0]} | Unexpected error scanning "
-                        f"account: {e}", "red"))
-            all_scan_errors.append(
-                {"account": sub_account[0], "name": sub_account[1], "region": "-",
-                 "function": "(entire account)",
-                 "reason": f"account scan failed: {str(e)[:150]}"})
-            continue
-        all_to_delete.extend(to_delete)
-        all_skipped.extend(skipped)
-        all_scan_errors.extend(scan_errors)
+    try:
+        for sub_account in sub_accounts:
+            try:
+                session = _session_for_account(sub_account, sts_client, management_account_id)
+            except Exception as e:
+                print(color(f"Account: {sub_account[0]} | Can't assume role, skipping. "
+                            f"Error: {e}", "red"))
+                assume_role_failures.append((sub_account[0], sub_account[1], str(e)))
+                continue
+            print(color(f"Account: {sub_account[0]} | Scanning {len(regions)} regions", "blue"))
+            try:
+                to_delete, skipped, scan_errors = _scan_account_lambdas(
+                    sub_account, session, regions, pattern)
+            except Exception as e:
+                # One account's unexpected scan error must not discard every other
+                # account's results — record it as a gap and carry on.
+                print(color(f"Account: {sub_account[0]} | Unexpected error scanning "
+                            f"account: {e}", "red"))
+                all_scan_errors.append(
+                    {"account": sub_account[0], "name": sub_account[1], "region": "-",
+                     "function": "(entire account)",
+                     "reason": f"account scan failed: {str(e)[:150]}"})
+                continue
+            all_to_delete.extend(to_delete)
+            all_skipped.extend(skipped)
+            all_scan_errors.extend(scan_errors)
+    except KeyboardInterrupt:
+        # Match the delete phase: abort cleanly instead of dumping a traceback.
+        # The scan is incomplete, so do not proceed to deletion.
+        print(color("\nInterrupted during scan - aborting before any deletion.", "yellow"))
+        print_lambda_summary([], [], all_scan_errors, all_skipped, assume_role_failures)
+        return 1
 
     # Listing + plan file
     print_lambda_plan(all_to_delete, all_skipped)
@@ -208,6 +215,7 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
 
     # Delete phase - re-assume roles fresh (the scan can outlive 1h STS creds)
     deleted, already_gone, failed = [], [], []
+    interrupted = False
     by_account = {}
     for d in all_to_delete:
         by_account.setdefault((d["account"], d["name"]), []).append(d)
@@ -220,15 +228,13 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
             except Exception as e:
                 print(color(f"Account: {account_id} | Can't assume role for delete, "
                             f"skipping. Error: {e}", "red"))
-                assume_role_failures.append((account_id, name, str(e)))
-                # These functions were in the plan but couldn't be deleted — record
-                # each as failed so the summary and exit code reflect the miss
-                # instead of silently under-reporting.
+                # These functions were planned but couldn't be deleted — record each
+                # as failed (a real operation failure) so the summary and exit code
+                # reflect the miss. Do NOT also add the account to the 'unreachable'
+                # list: that would double-report the same failure across two counters.
                 for it in items:
                     failed.append(dict(it, reason=f"delete skipped - could not assume "
                                                   f"role: {str(e)[:120]}"))
-                continue
-            if not items:
                 continue
             # Warm the session's client-creation caches single-threaded; boto3 Session
             # is not thread-safe for concurrent first-time client creation.
@@ -262,10 +268,25 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                         executor.shutdown(wait=False)
                     raise
     except KeyboardInterrupt:
+        interrupted = True
         print(color("\nInterrupted - stopping. Summary of work done so far:", "yellow"))
 
-    return print_lambda_summary(deleted, already_gone, failed + all_scan_errors,
-                                all_skipped, assume_role_failures)
+    # Account for functions that were planned but never attempted (e.g. the run
+    # was interrupted before reaching them), so an aborted run isn't mistaken for
+    # a completed one.
+    attempted = {(x["account"], x["region"], x["function"])
+                 for x in deleted + already_gone + failed}
+    not_attempted = [x for x in all_to_delete
+                     if (x["account"], x["region"], x["function"]) not in attempted]
+    if not_attempted:
+        print(color(f"{len(not_attempted)} planned function(s) were NOT attempted "
+                    f"(run interrupted before reaching them); re-run to finish them.",
+                    "yellow"))
+
+    rc = print_lambda_summary(deleted, already_gone, failed + all_scan_errors,
+                              all_skipped, assume_role_failures)
+    # An interrupted run left work undone — never report it as a clean success.
+    return max(rc, 1) if interrupted else rc
 
 
 def _run_cf_mode(sub_accounts, sts_client, management_account_id, regions,
@@ -333,10 +354,11 @@ def main(accounts, aws_profile_name, regions=None, just_print=False,
             print(color(f"Warning: DescribeOrganization not permitted ({e}); assuming the "
                         f"current account {management_account_id} is the management "
                         f"account.", "yellow"))
-        except Exception:
+        except Exception as e2:
             management_account_id = None
-            print(color(f"Warning: could not determine the management account ({e}); "
-                        f"every account will be accessed via assume-role.", "yellow"))
+            print(color(f"Warning: could not determine the management account "
+                        f"(DescribeOrganization: {e}; caller identity: {e2}); every "
+                        f"account will be accessed via assume-role.", "yellow"))
     sub_accounts = [(a["Id"], a["Name"]) for a in list_accounts if a["Status"] == "ACTIVE"]
     if account_filter:
         sub_accounts = [sa for sa in sub_accounts if sa[0] in account_filter]

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -161,8 +161,14 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
             all_scan_errors.extend(scan_errors)
     except KeyboardInterrupt:
         # Match the delete phase: abort cleanly instead of dumping a traceback.
-        # The scan is incomplete, so do not proceed to deletion.
+        # The scan is incomplete, so do not proceed to deletion — but still show
+        # what was already discovered so the operator isn't misled into thinking
+        # nothing was found.
         print(color("\nInterrupted during scan - aborting before any deletion.", "yellow"))
+        print_lambda_plan(all_to_delete, all_skipped)
+        if all_to_delete:
+            print(color(f"({len(all_to_delete)} function(s) were already identified but "
+                        f"will NOT be deleted because the scan was interrupted.)", "yellow"))
         print_lambda_summary([], [], all_scan_errors, all_skipped, assume_role_failures)
         return 1
 
@@ -236,37 +242,50 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                     failed.append(dict(it, reason=f"delete skipped - could not assume "
                                                   f"role: {str(e)[:120]}"))
                 continue
-            # Warm the session's client-creation caches single-threaded; boto3 Session
-            # is not thread-safe for concurrent first-time client creation.
-            session.client("lambda", region_name=items[0]["region"])
-            with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
-                future_to_item = {
-                    executor.submit(delete_lambda_function, session, it["region"],
-                                    it["function"]): it for it in items}
-                try:
-                    for future in concurrent.futures.as_completed(future_to_item):
-                        it = future_to_item[future]
-                        try:
-                            outcome = future.result()
-                            if outcome == "already gone":
-                                already_gone.append(it)
-                            else:
-                                deleted.append(it)
-                                print(color(f"Account: {account_id} | Deleted "
-                                            f"{it['function']} ({it['region']})", "green"))
-                        except Exception as e:
-                            it2 = dict(it, reason=str(e)[:200])
-                            failed.append(it2)
-                            print(color(f"Account: {account_id} | Failed to delete "
-                                        f"{it['function']} ({it['region']}): {e}", "red"))
-                except KeyboardInterrupt:
+            try:
+                # Warm the session's client-creation caches single-threaded; boto3
+                # Session is not thread-safe for concurrent first-time client creation.
+                session.client("lambda", region_name=items[0]["region"])
+                with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+                    future_to_item = {
+                        executor.submit(delete_lambda_function, session, it["region"],
+                                        it["function"]): it for it in items}
                     try:
-                        executor.shutdown(wait=False, cancel_futures=True)
-                    except TypeError:
-                        # cancel_futures was added in Python 3.9; on 3.8 fall back
-                        # to a plain shutdown so Ctrl+C still aborts cleanly.
-                        executor.shutdown(wait=False)
-                    raise
+                        for future in concurrent.futures.as_completed(future_to_item):
+                            it = future_to_item[future]
+                            try:
+                                outcome = future.result()
+                                if outcome == "already gone":
+                                    already_gone.append(it)
+                                else:
+                                    deleted.append(it)
+                                    print(color(f"Account: {account_id} | Deleted "
+                                                f"{it['function']} ({it['region']})", "green"))
+                            except Exception as e:
+                                it2 = dict(it, reason=str(e)[:200])
+                                failed.append(it2)
+                                print(color(f"Account: {account_id} | Failed to delete "
+                                            f"{it['function']} ({it['region']}): {e}", "red"))
+                    except KeyboardInterrupt:
+                        try:
+                            executor.shutdown(wait=False, cancel_futures=True)
+                        except TypeError:
+                            # cancel_futures was added in Python 3.9; on 3.8 fall back
+                            # to a plain shutdown so Ctrl+C still aborts cleanly.
+                            executor.shutdown(wait=False)
+                        raise
+            except Exception as e:
+                # An unexpected error for this account (e.g. the warm-up client call
+                # or executor setup) must not crash the whole run — record whatever
+                # of this account's functions weren't handled as failed and continue.
+                print(color(f"Account: {account_id} | Unexpected error during delete, "
+                            f"skipping remaining: {e}", "red"))
+                done = {(x["account"], x["region"], x["function"])
+                        for x in deleted + already_gone + failed}
+                for it in items:
+                    if (it["account"], it["region"], it["function"]) not in done:
+                        failed.append(dict(it, reason=f"delete error: {str(e)[:120]}"))
+                continue
     except KeyboardInterrupt:
         interrupted = True
         print(color("\nInterrupted - stopping. Summary of work done so far:", "yellow"))
@@ -361,7 +380,18 @@ def main(accounts, aws_profile_name, regions=None, just_print=False,
                         f"account will be accessed via assume-role.", "yellow"))
     sub_accounts = [(a["Id"], a["Name"]) for a in list_accounts if a["Status"] == "ACTIVE"]
     if account_filter:
+        active_ids = {sa[0] for sa in sub_accounts}
+        unknown = [aid for aid in account_filter if aid not in active_ids]
+        if unknown:
+            # Don't silently ignore a typo'd or inactive account id — that would let
+            # a run "succeed" while never targeting the account the operator meant.
+            print(color(f"Warning: {len(unknown)} requested account(s) are not ACTIVE "
+                        f"org accounts and will be skipped: {unknown}", "red"))
         sub_accounts = [sa for sa in sub_accounts if sa[0] in account_filter]
+        if not sub_accounts:
+            print(color("None of the requested --accounts match an ACTIVE org account; "
+                        "nothing to do. Exiting non-zero.", "red"))
+            return 1
     print(color(f"Accounts to process: {[sa[0] for sa in sub_accounts]}", "blue"))
 
     if lambda_name_contains:

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -82,11 +82,19 @@ def _session_for_account(sub_account, sts_client, management_account_id):
 
 
 def _scan_account_lambdas(sub_account, session, regions, pattern):
-    """Scan all regions of one account in parallel; return (to_delete, skipped)
-    with account id+name stamped on each result dict."""
-    to_delete, skipped = [], []
+    """Scan all regions of one account in parallel; return
+    (to_delete, skipped, scan_errors) with account id+name stamped on each result
+    dict. scan_errors carries regions that could not be scanned and functions
+    whose tags could not be read, so an incomplete scan is surfaced rather than
+    silently dropping target functions."""
+    to_delete, skipped, scan_errors = [], [], []
     if not regions:
-        return to_delete, skipped
+        return to_delete, skipped, scan_errors
+
+    def _stamp(items):
+        for item in items:
+            item.update({"account": sub_account[0], "name": sub_account[1]})
+
     # Warm the session's client-creation caches single-threaded; boto3 Session
     # is not thread-safe for concurrent first-time client creation.
     session.client("lambda", region_name=regions[0])
@@ -97,18 +105,21 @@ def _scan_account_lambdas(sub_account, session, regions, pattern):
         for future in concurrent.futures.as_completed(future_to_region):
             region = future_to_region[future]
             try:
-                region_delete, region_skipped = future.result()
+                region_delete, region_skipped, region_errors = future.result()
             except Exception as e:
+                # The whole region could not be scanned. Record it so its target
+                # functions are surfaced as a gap and counted, not silently lost.
                 print(color(f"Account: {sub_account[0]} | Failed to scan region "
                             f"{region}: {e}", "red"))
+                scan_errors.append({"region": region, "function": "(entire region)",
+                                    "reason": f"region scan failed: {str(e)[:150]}"})
+                _stamp([scan_errors[-1]])
                 continue
-            for d in region_delete:
-                d.update({"account": sub_account[0], "name": sub_account[1]})
-                to_delete.append(d)
-            for s in region_skipped:
-                s.update({"account": sub_account[0], "name": sub_account[1]})
-                skipped.append(s)
-    return to_delete, skipped
+            _stamp(region_delete); _stamp(region_skipped); _stamp(region_errors)
+            to_delete.extend(region_delete)
+            skipped.extend(region_skipped)
+            scan_errors.extend(region_errors)
+    return to_delete, skipped, scan_errors
 
 
 def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
@@ -119,7 +130,7 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
         "stacks are NOT touched — to remove the Stream Security integration itself, "
         "run without --lambda_name_contains.", "yellow"))
 
-    all_to_delete, all_skipped, assume_role_failures = [], [], []
+    all_to_delete, all_skipped, all_scan_errors, assume_role_failures = [], [], [], []
 
     # Scan phase
     for sub_account in sub_accounts:
@@ -131,12 +142,22 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
             assume_role_failures.append((sub_account[0], sub_account[1], str(e)))
             continue
         print(color(f"Account: {sub_account[0]} | Scanning {len(regions)} regions", "blue"))
-        to_delete, skipped = _scan_account_lambdas(sub_account, session, regions, pattern)
+        to_delete, skipped, scan_errors = _scan_account_lambdas(
+            sub_account, session, regions, pattern)
         all_to_delete.extend(to_delete)
         all_skipped.extend(skipped)
+        all_scan_errors.extend(scan_errors)
 
     # Listing + plan file
     print_lambda_plan(all_to_delete, all_skipped)
+    if all_scan_errors:
+        print(color(
+            f"WARNING: {len(all_scan_errors)} region(s)/function(s) could not be fully "
+            f"scanned — the plan below may be INCOMPLETE (these are reported in the run "
+            f"summary and make the run exit non-zero):", "yellow"))
+        for e in all_scan_errors:
+            print(color(f"  SCAN GAP | account {e['account']} | {e['region']} | "
+                        f"{e['function']} | {e['reason']}", "yellow"))
     plan_path = os.path.join(
         os.getcwd(), f"lambda_delete_plan_{time.strftime('%Y%m%d-%H%M%S')}.txt")
     if all_to_delete:
@@ -147,19 +168,21 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
             print(color(f"Could not write plan file to {plan_path}: {e} "
                         "(continuing - the plan above is still valid)", "yellow"))
 
-    def _surface_assume_role_failures():
-        return print_lambda_summary([], [], [], all_skipped, assume_role_failures)
+    # Scan gaps are surfaced as failures so they show in the summary and drive a
+    # non-zero exit code, even on paths that delete nothing.
+    def _surface_early():
+        return print_lambda_summary([], [], all_scan_errors, all_skipped, assume_role_failures)
 
     if just_print:
         print(color("Dry run (--just_print) - nothing deleted.", "green"))
-        return _surface_assume_role_failures()
+        return _surface_early()
     if not all_to_delete:
         print(color("No matching lambda functions found - nothing to delete.", "green"))
-        return _surface_assume_role_failures()
+        return _surface_early()
 
     account_count = len({d["account"] for d in all_to_delete})
     if not confirm_deletion(len(all_to_delete), account_count, sys.stdin.isatty, input):
-        return _surface_assume_role_failures()
+        return _surface_early()
 
     # Delete phase - re-assume roles fresh (the scan can outlive 1h STS creds)
     deleted, already_gone, failed = [], [], []
@@ -208,8 +231,8 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
     except KeyboardInterrupt:
         print(color("\nInterrupted - stopping. Summary of work done so far:", "yellow"))
 
-    return print_lambda_summary(deleted, already_gone, failed, all_skipped,
-                                assume_role_failures)
+    return print_lambda_summary(deleted, already_gone, failed + all_scan_errors,
+                                all_skipped, assume_role_failures)
 
 
 def _run_cf_mode(sub_accounts, sts_client, management_account_id, regions,
@@ -262,7 +285,16 @@ def main(accounts, aws_profile_name, regions=None, just_print=False,
 
     print("Fetching all accounts connected to the organization")
     list_accounts = get_all_accounts(org_client)
-    management_account_id = org_client.describe_organization()['Organization']['MasterAccountId']
+    # Used to route the management account through the current session instead of
+    # assume-role. If DescribeOrganization is not permitted, degrade gracefully to
+    # the previous behavior (every account via assume-role) rather than crashing.
+    try:
+        management_account_id = org_client.describe_organization()['Organization']['MasterAccountId']
+    except Exception as e:
+        management_account_id = None
+        print(color(f"Warning: could not determine the management account "
+                    f"(organizations:DescribeOrganization): {e}. Every account will be "
+                    f"accessed via assume-role.", "yellow"))
     sub_accounts = [(a["Id"], a["Name"]) for a in list_accounts if a["Status"] == "ACTIVE"]
     if account_filter:
         sub_accounts = [sa for sa in sub_accounts if sa[0] in account_filter]

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -24,6 +24,11 @@ class _DeleteIntegrationParser(argparse.ArgumentParser):
             self.error(
                 "--lambda_name_contains cannot be combined with --force_delete_failed "
                 "or --stack_name_contains (lambda-only mode does not touch stacks).")
+        if ns.lambda_name_contains:
+            try:
+                validate_lambda_pattern(ns.lambda_name_contains)
+            except ValueError as e:
+                self.error(str(e))
         return ns
 
 
@@ -135,19 +140,26 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
     plan_path = os.path.join(
         os.getcwd(), f"lambda_delete_plan_{time.strftime('%Y%m%d-%H%M%S')}.txt")
     if all_to_delete:
-        write_plan_file(all_to_delete, plan_path)
-        print(color(f"Full plan written to: {plan_path}", "blue"))
+        try:
+            write_plan_file(all_to_delete, plan_path)
+            print(color(f"Full plan written to: {plan_path}", "blue"))
+        except Exception as e:
+            print(color(f"Could not write plan file to {plan_path}: {e} "
+                        "(continuing - the plan above is still valid)", "yellow"))
+
+    def _surface_assume_role_failures():
+        return print_lambda_summary([], [], [], all_skipped, assume_role_failures)
 
     if just_print:
         print(color("Dry run (--just_print) - nothing deleted.", "green"))
-        return 0
+        return _surface_assume_role_failures()
     if not all_to_delete:
         print(color("No matching lambda functions found - nothing to delete.", "green"))
-        return 0
+        return _surface_assume_role_failures()
 
     account_count = len({d["account"] for d in all_to_delete})
     if not confirm_deletion(len(all_to_delete), account_count, sys.stdin.isatty, input):
-        return 0
+        return _surface_assume_role_failures()
 
     # Delete phase - re-assume roles fresh (the scan can outlive 1h STS creds)
     deleted, already_gone, failed = [], [], []
@@ -174,21 +186,25 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                 future_to_item = {
                     executor.submit(delete_lambda_function, session, it["region"],
                                     it["function"]): it for it in items}
-                for future in concurrent.futures.as_completed(future_to_item):
-                    it = future_to_item[future]
-                    try:
-                        outcome = future.result()
-                        if outcome == "already gone":
-                            already_gone.append(it)
-                        else:
-                            deleted.append(it)
-                            print(color(f"Account: {account_id} | Deleted "
-                                        f"{it['function']} ({it['region']})", "green"))
-                    except Exception as e:
-                        it2 = dict(it, reason=str(e)[:200])
-                        failed.append(it2)
-                        print(color(f"Account: {account_id} | Failed to delete "
-                                    f"{it['function']} ({it['region']}): {e}", "red"))
+                try:
+                    for future in concurrent.futures.as_completed(future_to_item):
+                        it = future_to_item[future]
+                        try:
+                            outcome = future.result()
+                            if outcome == "already gone":
+                                already_gone.append(it)
+                            else:
+                                deleted.append(it)
+                                print(color(f"Account: {account_id} | Deleted "
+                                            f"{it['function']} ({it['region']})", "green"))
+                        except Exception as e:
+                            it2 = dict(it, reason=str(e)[:200])
+                            failed.append(it2)
+                            print(color(f"Account: {account_id} | Failed to delete "
+                                        f"{it['function']} ({it['region']}): {e}", "red"))
+                except KeyboardInterrupt:
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    raise
     except KeyboardInterrupt:
         print(color("\nInterrupted - stopping. Summary of work done so far:", "yellow"))
 

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -142,8 +142,19 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
             assume_role_failures.append((sub_account[0], sub_account[1], str(e)))
             continue
         print(color(f"Account: {sub_account[0]} | Scanning {len(regions)} regions", "blue"))
-        to_delete, skipped, scan_errors = _scan_account_lambdas(
-            sub_account, session, regions, pattern)
+        try:
+            to_delete, skipped, scan_errors = _scan_account_lambdas(
+                sub_account, session, regions, pattern)
+        except Exception as e:
+            # One account's unexpected scan error must not discard every other
+            # account's results — record it as a gap and carry on.
+            print(color(f"Account: {sub_account[0]} | Unexpected error scanning "
+                        f"account: {e}", "red"))
+            all_scan_errors.append(
+                {"account": sub_account[0], "name": sub_account[1], "region": "-",
+                 "function": "(entire account)",
+                 "reason": f"account scan failed: {str(e)[:150]}"})
+            continue
         all_to_delete.extend(to_delete)
         all_skipped.extend(skipped)
         all_scan_errors.extend(scan_errors)
@@ -182,7 +193,18 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
 
     account_count = len({d["account"] for d in all_to_delete})
     if not confirm_deletion(len(all_to_delete), account_count, sys.stdin.isatty, input):
-        return _surface_early()
+        early = _surface_early()
+        if not sys.stdin.isatty():
+            # Non-interactive and we had functions pending: the tool refused to
+            # delete because it couldn't confirm. That is NOT success — exit
+            # non-zero so a cron/CI caller doesn't record it as a completed run.
+            print(color("Refused to delete without an interactive confirmation while "
+                        f"{len(all_to_delete)} function(s) were pending — exiting non-zero.",
+                        "red"))
+            return max(early, 1)
+        # Interactive operator deliberately declined: a clean abort, exit reflects
+        # only real gaps (scan errors), which _surface_early already returned.
+        return early
 
     # Delete phase - re-assume roles fresh (the scan can outlive 1h STS creds)
     deleted, already_gone, failed = [], [], []
@@ -199,6 +221,12 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                 print(color(f"Account: {account_id} | Can't assume role for delete, "
                             f"skipping. Error: {e}", "red"))
                 assume_role_failures.append((account_id, name, str(e)))
+                # These functions were in the plan but couldn't be deleted — record
+                # each as failed so the summary and exit code reflect the miss
+                # instead of silently under-reporting.
+                for it in items:
+                    failed.append(dict(it, reason=f"delete skipped - could not assume "
+                                                  f"role: {str(e)[:120]}"))
                 continue
             if not items:
                 continue
@@ -226,7 +254,12 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                             print(color(f"Account: {account_id} | Failed to delete "
                                         f"{it['function']} ({it['region']}): {e}", "red"))
                 except KeyboardInterrupt:
-                    executor.shutdown(wait=False, cancel_futures=True)
+                    try:
+                        executor.shutdown(wait=False, cancel_futures=True)
+                    except TypeError:
+                        # cancel_futures was added in Python 3.9; on 3.8 fall back
+                        # to a plain shutdown so Ctrl+C still aborts cleanly.
+                        executor.shutdown(wait=False)
                     raise
     except KeyboardInterrupt:
         print(color("\nInterrupted - stopping. Summary of work done so far:", "yellow"))
@@ -251,12 +284,14 @@ def _run_cf_mode(sub_accounts, sts_client, management_account_id, regions,
                                      force_delete_failed, stack_name_contains)
     if assume_role_failures:
         print(color("=" * 60, "blue"))
-        print(color(f"{len(assume_role_failures)} account(s) unreachable (assume-role failed):", "red"))
-        for account_id, name, err in assume_role_failures:
-            print(color(f"  ASSUME-ROLE FAILED | account {account_id} ({name}) | {err}", "red"))
-    # Non-zero when any account could not be reached, so scripted/CI callers see
-    # a partial run as a failure (mirrors lambda mode's exit-code contract).
-    return len(assume_role_failures)
+        print(color(f"{len(assume_role_failures)} account(s) unreachable "
+                    f"(assume-role failed):", "yellow"))
+        for line in format_assume_role_failure_lines(assume_role_failures):
+            print(color(line, "yellow"))
+    # Unreachable accounts are reported but do not fail the exit code (they are a
+    # gap, not an operation failure). The underlying stack-delete helper does not
+    # surface per-stack failures, so CF mode has no operation-failure count.
+    return 0
 
 
 def main(accounts, aws_profile_name, regions=None, just_print=False,
@@ -286,15 +321,22 @@ def main(accounts, aws_profile_name, regions=None, just_print=False,
     print("Fetching all accounts connected to the organization")
     list_accounts = get_all_accounts(org_client)
     # Used to route the management account through the current session instead of
-    # assume-role. If DescribeOrganization is not permitted, degrade gracefully to
-    # the previous behavior (every account via assume-role) rather than crashing.
+    # assume-role (it cannot assume OrganizationAccountAccessRole into itself). If
+    # DescribeOrganization is not permitted, fall back to the caller's own account
+    # id: when the tool is run from the management account (the usual case) this
+    # still identifies it correctly, avoiding both a crash and a doomed assume-role.
     try:
         management_account_id = org_client.describe_organization()['Organization']['MasterAccountId']
     except Exception as e:
-        management_account_id = None
-        print(color(f"Warning: could not determine the management account "
-                    f"(organizations:DescribeOrganization): {e}. Every account will be "
-                    f"accessed via assume-role.", "yellow"))
+        try:
+            management_account_id = sts_client.get_caller_identity()['Account']
+            print(color(f"Warning: DescribeOrganization not permitted ({e}); assuming the "
+                        f"current account {management_account_id} is the management "
+                        f"account.", "yellow"))
+        except Exception:
+            management_account_id = None
+            print(color(f"Warning: could not determine the management account ({e}); "
+                        f"every account will be accessed via assume-role.", "yellow"))
     sub_accounts = [(a["Id"], a["Name"]) for a in list_accounts if a["Status"] == "ACTIVE"]
     if account_filter:
         sub_accounts = [sa for sa in sub_accounts if sa[0] in account_filter]

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -330,9 +330,11 @@ def _run_cf_mode(sub_accounts, sts_client, management_account_id, regions,
             print(color(line, "yellow"))
     # Unreachable accounts are reported but do not fail the exit code (they are a
     # gap, not an operation failure). CF mode does not compute a per-stack failure
-    # count: delete_stacks_in_all_regions only *initiates* deletion (asynchronous,
-    # no waiter), so stack-deletion outcomes are never observed here; a failure to
-    # initiate a delete propagates as an exception rather than a counted failure.
+    # count, and its stack helpers are not resilient: filter_ll_stacks_by_name
+    # swallows list errors (a region that can't be listed reports zero stacks and
+    # is silently skipped), while delete_stack is unguarded (an error initiating a
+    # delete aborts the run with a traceback). Hardening that legacy path is out of
+    # scope here; this returns 0 because there is no tracked failure count to report.
     return 0
 
 

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -80,6 +80,11 @@ def _scan_account_lambdas(sub_account, session, regions, pattern):
     """Scan all regions of one account in parallel; return (to_delete, skipped)
     with account id+name stamped on each result dict."""
     to_delete, skipped = [], []
+    if not regions:
+        return to_delete, skipped
+    # Warm the session's client-creation caches single-threaded; boto3 Session
+    # is not thread-safe for concurrent first-time client creation.
+    session.client("lambda", region_name=regions[0])
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
         future_to_region = {
             executor.submit(scan_lambdas_in_region, session, region, pattern): region
@@ -160,6 +165,11 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                             f"skipping. Error: {e}", "red"))
                 assume_role_failures.append((account_id, name, str(e)))
                 continue
+            if not items:
+                continue
+            # Warm the session's client-creation caches single-threaded; boto3 Session
+            # is not thread-safe for concurrent first-time client creation.
+            session.client("lambda", region_name=items[0]["region"])
             with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
                 future_to_item = {
                     executor.submit(delete_lambda_function, session, it["region"],

--- a/tests/test_delete_integration_cf_mode.py
+++ b/tests/test_delete_integration_cf_mode.py
@@ -8,7 +8,7 @@ from src.python.utilities import organization_delete_integration as mod
 
 
 class TestCfModeExitCode(unittest.TestCase):
-    def test_assume_role_failures_counted_in_exit_code(self):
+    def test_unreachable_account_reported_but_does_not_fail_exit(self):
         accounts = [("111", "acct-a"), ("222", "acct-b")]
 
         def fake_session(sub_account, sts_client, mgmt):
@@ -22,8 +22,10 @@ class TestCfModeExitCode(unittest.TestCase):
                                   regions=["us-east-1"], just_print=True,
                                   force_delete_failed=False, stack_name_contains=None)
 
-        self.assertEqual(rc, 1)                      # one unreachable account -> non-zero
-        self.assertEqual(del_stacks.call_count, 1)   # only the reachable account was processed
+        # An unreachable account is a reported gap, not an operation failure, so it
+        # does not flip the exit code; the reachable account is still processed.
+        self.assertEqual(rc, 0)
+        self.assertEqual(del_stacks.call_count, 1)
 
     def test_clean_run_returns_zero(self):
         accounts = [("111", "acct-a")]

--- a/tests/test_delete_integration_cf_mode.py
+++ b/tests/test_delete_integration_cf_mode.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.python.utilities import organization_delete_integration as mod
+
+
+class TestCfModeExitCode(unittest.TestCase):
+    def test_assume_role_failures_counted_in_exit_code(self):
+        accounts = [("111", "acct-a"), ("222", "acct-b")]
+
+        def fake_session(sub_account, sts_client, mgmt):
+            if sub_account[0] == "222":
+                raise Exception("access denied")
+            return object()
+
+        with patch.object(mod, "_session_for_account", side_effect=fake_session), \
+                patch.object(mod, "delete_stacks_in_all_regions") as del_stacks:
+            rc = mod._run_cf_mode(accounts, sts_client=None, management_account_id="111",
+                                  regions=["us-east-1"], just_print=True,
+                                  force_delete_failed=False, stack_name_contains=None)
+
+        self.assertEqual(rc, 1)                      # one unreachable account -> non-zero
+        self.assertEqual(del_stacks.call_count, 1)   # only the reachable account was processed
+
+    def test_clean_run_returns_zero(self):
+        accounts = [("111", "acct-a")]
+        with patch.object(mod, "_session_for_account", return_value=object()), \
+                patch.object(mod, "delete_stacks_in_all_regions"):
+            rc = mod._run_cf_mode(accounts, None, "999", ["us-east-1"], True, False, None)
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_delete_integration_cf_mode.py
+++ b/tests/test_delete_integration_cf_mode.py
@@ -35,5 +35,27 @@ class TestCfModeExitCode(unittest.TestCase):
         self.assertEqual(rc, 0)
 
 
+class TestAccountFilterValidation(unittest.TestCase):
+    def _patches(self):
+        # Org has one ACTIVE account, 111; describe_organization/get_all_accounts mocked.
+        org = mock_org = __import__("unittest").mock.MagicMock()
+        org.describe_organization.return_value = {"Organization": {"MasterAccountId": "111"}}
+        return org
+
+    def test_all_unknown_accounts_exits_nonzero_without_running_a_mode(self):
+        org = self._patches()
+        with patch.object(mod.boto3, "client", return_value=org), \
+                patch.object(mod, "get_all_accounts",
+                             return_value=[{"Id": "111", "Name": "a", "Status": "ACTIVE"}]), \
+                patch.object(mod, "_run_lambda_mode") as run_lambda, \
+                patch.object(mod, "_run_cf_mode") as run_cf:
+            rc = mod.main(accounts="999999999999", aws_profile_name=None,
+                          regions="us-east-1", just_print=True,
+                          lambda_name_contains="streamsec")
+        self.assertEqual(rc, 1)                 # no valid target -> non-zero
+        run_lambda.assert_not_called()          # and neither mode is entered
+        run_cf.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_delete_integration_cli.py
+++ b/tests/test_delete_integration_cli.py
@@ -28,6 +28,11 @@ class TestArgParser(unittest.TestCase):
             parser.parse_args(
                 ["--lambda_name_contains", "StreamSec", "--stack_name_contains", "Light"])
 
+    def test_lambda_pattern_too_short_rejected_at_parse_time(self):
+        parser = build_arg_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["--lambda_name_contains", "ab"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_delete_integration_cli.py
+++ b/tests/test_delete_integration_cli.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.python.utilities.organization_delete_integration import build_arg_parser
+
+
+class TestArgParser(unittest.TestCase):
+    def test_lambda_mode_parses(self):
+        args = build_arg_parser().parse_args(
+            ["--lambda_name_contains", "StreamSec"])
+        self.assertEqual(args.lambda_name_contains, "StreamSec")
+
+    def test_regions_and_accounts_parse(self):
+        args = build_arg_parser().parse_args(
+            ["--accounts", "111,222", "--regions", "us-east-1,eu-west-1"])
+        self.assertEqual(args.accounts, "111,222")
+        self.assertEqual(args.regions, "us-east-1,eu-west-1")
+
+    def test_profile_defaults_to_none(self):
+        args = build_arg_parser().parse_args([])
+        self.assertIsNone(args.aws_profile_name)
+
+    def test_lambda_mode_conflicts_with_stack_flags(self):
+        parser = build_arg_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(
+                ["--lambda_name_contains", "StreamSec", "--stack_name_contains", "Light"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_delete_integration_lambda_scan.py
+++ b/tests/test_delete_integration_lambda_scan.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.python.utilities import organization_delete_integration as mod
+
+
+class TestLambdaScanErrorsAffectExit(unittest.TestCase):
+    def test_scan_gap_causes_nonzero_exit_even_on_just_print(self):
+        accounts = [("111", "acct-a")]
+
+        def fake_scan(sub_account, session, regions, pattern):
+            # No deletable functions, but one region/function couldn't be scanned.
+            return [], [], [{"account": "111", "name": "acct-a", "region": "us-east-1",
+                             "function": "f", "reason": "could not read tags"}]
+
+        with patch.object(mod, "_session_for_account", return_value=object()), \
+                patch.object(mod, "_scan_account_lambdas", side_effect=fake_scan):
+            rc = mod._run_lambda_mode(accounts, sts_client=None, management_account_id="999",
+                                      regions=["us-east-1"], pattern="stream", just_print=True)
+
+        self.assertEqual(rc, 1)   # scan gap surfaced -> non-zero, not a silent success
+
+    def test_clean_scan_returns_zero(self):
+        accounts = [("111", "acct-a")]
+
+        def fake_scan(sub_account, session, regions, pattern):
+            return [], [], []
+
+        with patch.object(mod, "_session_for_account", return_value=object()), \
+                patch.object(mod, "_scan_account_lambdas", side_effect=fake_scan):
+            rc = mod._run_lambda_mode(accounts, sts_client=None, management_account_id="999",
+                                      regions=["us-east-1"], pattern="stream", just_print=True)
+
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_delete_integration_lambda_scan.py
+++ b/tests/test_delete_integration_lambda_scan.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import os
 import sys
 import unittest
@@ -70,6 +72,35 @@ class TestLambdaScanErrorsAffectExit(unittest.TestCase):
                                       regions=["us-east-1"], pattern="stream", just_print=True)
 
         self.assertGreaterEqual(rc, 1)
+
+    def test_delete_phase_assume_role_failure_counted_once_as_failed(self):
+        accounts = [("111", "acct-a")]
+
+        def fake_scan(sub_account, session, regions, pattern):
+            return ([{"account": "111", "name": "acct-a", "region": "us-east-1",
+                      "function": "target"}], [], [])
+
+        # Session succeeds during scan, then fails when re-assumed for the delete.
+        outcomes = [object(), Exception("creds expired")]
+
+        def fake_session(sub_account, sts_client, mgmt):
+            r = outcomes.pop(0)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        buf = io.StringIO()
+        with patch.object(mod, "_session_for_account", side_effect=fake_session), \
+                patch.object(mod, "_scan_account_lambdas", side_effect=fake_scan), \
+                patch.object(mod, "confirm_deletion", return_value=True), \
+                contextlib.redirect_stdout(buf):
+            rc = mod._run_lambda_mode(accounts, sts_client=None, management_account_id="999",
+                                      regions=["us-east-1"], pattern="target", just_print=False)
+
+        out = buf.getvalue()
+        self.assertEqual(rc, 1)                        # the planned function counts as one failure
+        self.assertIn("1 failed", out)
+        self.assertIn("0 accounts unreachable", out)   # NOT also double-reported as unreachable
 
 
 if __name__ == "__main__":

--- a/tests/test_delete_integration_lambda_scan.py
+++ b/tests/test_delete_integration_lambda_scan.py
@@ -36,6 +36,41 @@ class TestLambdaScanErrorsAffectExit(unittest.TestCase):
 
         self.assertEqual(rc, 0)
 
+    def test_non_tty_refusal_with_pending_work_exits_nonzero(self):
+        accounts = [("111", "acct-a")]
+
+        def fake_scan(sub_account, session, regions, pattern):
+            # A clean scan (no gaps) that DID find a function to delete.
+            return ([{"account": "111", "name": "acct-a", "region": "us-east-1",
+                      "function": "target"}], [], [])
+
+        with patch.object(mod, "_session_for_account", return_value=object()), \
+                patch.object(mod, "_scan_account_lambdas", side_effect=fake_scan), \
+                patch.object(mod.sys.stdin, "isatty", return_value=False):
+            # just_print=False so it reaches confirm_deletion, which refuses on the
+            # non-TTY stdin — the run must NOT report success.
+            rc = mod._run_lambda_mode(accounts, sts_client=None, management_account_id="999",
+                                      regions=["us-east-1"], pattern="stream", just_print=False)
+
+        self.assertGreaterEqual(rc, 1)
+
+    def test_account_scan_crash_is_recorded_not_fatal(self):
+        accounts = [("111", "acct-a"), ("222", "acct-b")]
+
+        def fake_scan(sub_account, session, regions, pattern):
+            if sub_account[0] == "111":
+                raise RuntimeError("boom")   # one account blows up mid-scan
+            return [], [], []
+
+        with patch.object(mod, "_session_for_account", return_value=object()), \
+                patch.object(mod, "_scan_account_lambdas", side_effect=fake_scan):
+            # Must not raise; the crashing account becomes a scan gap (exit non-zero),
+            # the other account is still scanned.
+            rc = mod._run_lambda_mode(accounts, sts_client=None, management_account_id="999",
+                                      regions=["us-east-1"], pattern="stream", just_print=True)
+
+        self.assertGreaterEqual(rc, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -35,14 +35,42 @@ class TestScanLambdasInRegion(unittest.TestCase):
         )
         session = _session_with_lambda(client)
 
-        to_delete, skipped = scan_lambdas_in_region(session, "us-east-1", "streamsec")
+        to_delete, skipped, scan_errors = scan_lambdas_in_region(session, "us-east-1", "streamsec")
 
         self.assertEqual([d["function"] for d in to_delete], ["StreamSec_A"])
         self.assertEqual(len(skipped), 1)
         self.assertEqual(skipped[0]["function"], "StreamSec_B")
         self.assertEqual(skipped[0]["stack"], "LightlyticsStack-x")
+        self.assertEqual(scan_errors, [])
         # list_tags must be called only for name-matched functions (A and B), not C
         self.assertEqual(client.list_tags.call_count, 2)
+
+    def test_tag_failure_excludes_function_and_records_error(self):
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{
+            "Functions": [
+                {"FunctionName": "StreamSec_ok", "FunctionArn": "arn:ok"},
+                {"FunctionName": "StreamSec_bad", "FunctionArn": "arn:bad"},
+            ]
+        }]
+        client.get_paginator.return_value = paginator
+
+        def _tags(Resource):
+            if Resource == "arn:bad":
+                raise Exception("AccessDenied on ListTags")
+            return {"Tags": {}}
+        client.list_tags.side_effect = _tags
+        session = _session_with_lambda(client)
+
+        to_delete, skipped, scan_errors = scan_lambdas_in_region(session, "us-east-1", "streamsec")
+
+        # A tag failure must NOT abort the region: the good function is still found,
+        # the bad one is left out of to_delete and recorded as a scan error.
+        self.assertEqual([d["function"] for d in to_delete], ["StreamSec_ok"])
+        self.assertEqual(len(scan_errors), 1)
+        self.assertEqual(scan_errors[0]["function"], "StreamSec_bad")
+        self.assertIn("could not read tags", scan_errors[0]["reason"])
 
 
 class TestDeleteLambdaFunction(unittest.TestCase):

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.python.common.boto_common import (
+    scan_lambdas_in_region,
+    delete_lambda_function,
+    CFN_STACK_NAME_TAG,
+)
+
+
+def _session_with_lambda(client):
+    session = MagicMock()
+    session.client.return_value = client
+    return session
+
+
+class TestScanLambdasInRegion(unittest.TestCase):
+    def test_splits_matches_and_cfn_managed(self):
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{
+            "Functions": [
+                {"FunctionName": "StreamSec_A", "FunctionArn": "arn:A"},
+                {"FunctionName": "StreamSec_B", "FunctionArn": "arn:B"},
+                {"FunctionName": "unrelated",   "FunctionArn": "arn:C"},
+            ]
+        }]
+        client.get_paginator.return_value = paginator
+        client.list_tags.side_effect = lambda Resource: (
+            {"Tags": {CFN_STACK_NAME_TAG: "LightlyticsStack-x"}} if Resource == "arn:B"
+            else {"Tags": {}}
+        )
+        session = _session_with_lambda(client)
+
+        to_delete, skipped = scan_lambdas_in_region(session, "us-east-1", "streamsec")
+
+        self.assertEqual([d["function"] for d in to_delete], ["StreamSec_A"])
+        self.assertEqual(len(skipped), 1)
+        self.assertEqual(skipped[0]["function"], "StreamSec_B")
+        self.assertEqual(skipped[0]["stack"], "LightlyticsStack-x")
+        # list_tags must be called only for name-matched functions (A and B), not C
+        self.assertEqual(client.list_tags.call_count, 2)
+
+
+class TestDeleteLambdaFunction(unittest.TestCase):
+    def test_deleted(self):
+        client = MagicMock()
+        client.exceptions.ResourceNotFoundException = type(
+            "ResourceNotFoundException", (Exception,), {})
+        session = _session_with_lambda(client)
+        self.assertEqual(delete_lambda_function(session, "us-east-1", "fn"), "deleted")
+
+    def test_already_gone(self):
+        client = MagicMock()
+        not_found = type("ResourceNotFoundException", (Exception,), {})
+        client.exceptions.ResourceNotFoundException = not_found
+        client.delete_function.side_effect = not_found()
+        session = _session_with_lambda(client)
+        self.assertEqual(delete_lambda_function(session, "us-east-1", "fn"), "already gone")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lambda_delete_confirm.py
+++ b/tests/test_lambda_delete_confirm.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.python.common.boto_common import confirm_deletion
+
+
+class TestConfirmDeletion(unittest.TestCase):
+    def test_typed_delete_on_tty_confirms(self):
+        self.assertTrue(confirm_deletion(5, 2, lambda: True, lambda _p: "delete"))
+
+    def test_wrong_word_aborts(self):
+        self.assertFalse(confirm_deletion(5, 2, lambda: True, lambda _p: "yes"))
+
+    def test_non_tty_refuses_without_prompting(self):
+        def _input(_p):
+            raise AssertionError("input must not be called on a non-tty")
+        self.assertFalse(confirm_deletion(5, 2, lambda: False, _input))
+
+    def test_eof_aborts(self):
+        def _input(_p):
+            raise EOFError()
+        self.assertFalse(confirm_deletion(5, 2, lambda: True, _input))
+
+    def test_keyboard_interrupt_aborts(self):
+        def _input(_p):
+            raise KeyboardInterrupt()
+        self.assertFalse(confirm_deletion(5, 2, lambda: True, _input))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lambda_delete_helpers.py
+++ b/tests/test_lambda_delete_helpers.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.python.common.boto_common import (
+    validate_lambda_pattern,
+    lambda_name_matches,
+    is_cfn_managed,
+    CFN_STACK_NAME_TAG,
+)
+
+
+class TestValidateLambdaPattern(unittest.TestCase):
+    def test_valid_pattern_returned_stripped(self):
+        self.assertEqual(validate_lambda_pattern("  StreamSec  "), "StreamSec")
+
+    def test_none_raises(self):
+        with self.assertRaises(ValueError):
+            validate_lambda_pattern(None)
+
+    def test_too_short_raises(self):
+        with self.assertRaises(ValueError):
+            validate_lambda_pattern("ab")
+
+    def test_blank_raises(self):
+        with self.assertRaises(ValueError):
+            validate_lambda_pattern("   ")
+
+
+class TestLambdaNameMatches(unittest.TestCase):
+    def test_case_insensitive_substring(self):
+        self.assertTrue(lambda_name_matches("StreamSec_Collector", "streamsec"))
+
+    def test_no_match(self):
+        self.assertFalse(lambda_name_matches("my-prod-fn", "streamsec"))
+
+
+class TestIsCfnManaged(unittest.TestCase):
+    def test_true_when_tag_present(self):
+        self.assertTrue(is_cfn_managed({CFN_STACK_NAME_TAG: "LightlyticsStack-abc"}))
+
+    def test_false_when_absent(self):
+        self.assertFalse(is_cfn_managed({"env": "prod"}))
+
+    def test_false_when_none(self):
+        self.assertFalse(is_cfn_managed(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lambda_delete_helpers.py
+++ b/tests/test_lambda_delete_helpers.py
@@ -9,6 +9,7 @@ from src.python.common.boto_common import (
     is_cfn_managed,
     CFN_STACK_NAME_TAG,
 )
+from src.python.common.boto_common import build_account_rollup, format_plan_lines
 
 
 class TestValidateLambdaPattern(unittest.TestCase):
@@ -45,6 +46,34 @@ class TestIsCfnManaged(unittest.TestCase):
 
     def test_false_when_none(self):
         self.assertFalse(is_cfn_managed(None))
+
+
+class TestBuildAccountRollup(unittest.TestCase):
+    def _results(self):
+        return [
+            {"account": "111", "name": "acme-prod", "region": "us-east-1", "function": "a"},
+            {"account": "111", "name": "acme-prod", "region": "us-east-1", "function": "b"},
+            {"account": "222", "name": "acme-dev", "region": "eu-west-1", "function": "c"},
+        ]
+
+    def test_counts_and_sort_desc(self):
+        rollup = build_account_rollup(self._results())
+        self.assertEqual(rollup[0], ("111", "acme-prod", 2))
+        self.assertEqual(rollup[1], ("222", "acme-dev", 1))
+
+    def test_empty(self):
+        self.assertEqual(build_account_rollup([]), [])
+
+
+class TestFormatPlanLines(unittest.TestCase):
+    def test_sorted_lines(self):
+        results = [
+            {"account": "222", "name": "d", "region": "us-east-1", "function": "z"},
+            {"account": "111", "name": "p", "region": "us-east-1", "function": "a"},
+        ]
+        lines = format_plan_lines(results)
+        self.assertEqual(lines[0], "111 | us-east-1 | a")
+        self.assertEqual(lines[1], "222 | us-east-1 | z")
 
 
 if __name__ == "__main__":

--- a/tests/test_lambda_delete_report.py
+++ b/tests/test_lambda_delete_report.py
@@ -34,7 +34,15 @@ class TestPrintSummaryExitCount(unittest.TestCase):
             skipped_cfn=[{"account": "3", "function": "g", "stack": "s"}],
             assume_role_failures=[("9", "acc9", "denied")],
         )
-        self.assertEqual(code, 2)
+        # Only operation failures count toward the exit code; the unreachable
+        # account is reported but does not.
+        self.assertEqual(code, 1)
+
+    def test_unreachable_accounts_do_not_affect_exit_code(self):
+        code = print_lambda_summary(
+            deleted=[{"account": "1"}], already_gone=[], failed=[], skipped_cfn=[],
+            assume_role_failures=[("9", "acc9", "denied"), ("8", "acc8", "denied")])
+        self.assertEqual(code, 0)
 
     def test_clean_run_returns_zero(self):
         code = print_lambda_summary([{"account": "1"}], [], [], [], [])

--- a/tests/test_lambda_delete_report.py
+++ b/tests/test_lambda_delete_report.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.python.common.boto_common import (
+    write_plan_file,
+    print_lambda_plan,
+    print_lambda_summary,
+)
+
+
+class TestWritePlanFile(unittest.TestCase):
+    def test_writes_sorted_lines(self):
+        results = [
+            {"account": "222", "name": "d", "region": "us-east-1", "function": "z"},
+            {"account": "111", "name": "p", "region": "us-east-1", "function": "a"},
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "plan.txt")
+            write_plan_file(results, path)
+            with open(path) as f:
+                lines = f.read().splitlines()
+        self.assertEqual(lines, ["111 | us-east-1 | a", "222 | us-east-1 | z"])
+
+
+class TestPrintSummaryExitCount(unittest.TestCase):
+    def test_returns_failure_plus_assume_role_count(self):
+        code = print_lambda_summary(
+            deleted=[{"account": "1"}],
+            already_gone=[],
+            failed=[{"account": "2", "region": "us-east-1", "function": "f", "reason": "boom"}],
+            skipped_cfn=[{"account": "3", "function": "g", "stack": "s"}],
+            assume_role_failures=[("9", "acc9", "denied")],
+        )
+        self.assertEqual(code, 2)
+
+    def test_clean_run_returns_zero(self):
+        code = print_lambda_summary([{"account": "1"}], [], [], [], [])
+        self.assertEqual(code, 0)
+
+
+class TestPrintPlanEmptySafe(unittest.TestCase):
+    def test_no_crash_on_empty(self):
+        print_lambda_plan([], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lambda_delete_report.py
+++ b/tests/test_lambda_delete_report.py
@@ -26,7 +26,7 @@ class TestWritePlanFile(unittest.TestCase):
 
 
 class TestPrintSummaryExitCount(unittest.TestCase):
-    def test_returns_failure_plus_assume_role_count(self):
+    def test_only_operation_failures_count_toward_exit_code(self):
         code = print_lambda_summary(
             deleted=[{"account": "1"}],
             already_gone=[],


### PR DESCRIPTION
## What

Adds a **lambda-only delete mode** to `organization_delete_integration.py` for deleting specific Lambda functions that are **not** managed by CloudFormation, across an AWS Organization. The default CloudFormation stack-deletion mode is unchanged aside from the two additions below.

## Modes

- **CF mode (default):** deletes the Stream Security / Lightlytics CloudFormation stacks (removes the integration).
- **Lambda-only mode (`--lambda_name_contains <str>`):** deletes only Lambda functions whose name contains the string (case-insensitive, min 3 chars). Never touches stacks or removes the integration; prints a banner making that explicit. Mutually exclusive with the stack-only flags.

## Behavior

- **CFN-managed protection:** functions tagged `aws:cloudformation:stack-name` are excluded from deletion and reported as skipped.
- **Scan → list → confirm → delete:** scans all target accounts/regions in parallel, prints a per-account roll-up + total + full list, writes a plan file, then requires typing `delete` to proceed. `--just_print` stops after the listing.
- **Safe at scale:** non-TTY guard refuses instead of hanging; Ctrl+C cancels queued deletes and still prints a summary; adaptive retries + client timeouts; per-account/region/function failures are recorded and skipped, not fatal. End-of-run summary reports counts and lists any accounts where assume-role failed.
- **Exit-code policy (operation failures only):** the run exits non-zero on genuine operation failures — delete errors, scan gaps (a region/function whose state couldn't be read), a non-interactive run that had work but couldn't get confirmation, and interrupted runs. Accounts that are merely **unreachable** (assume-role failed) are reported prominently but do **not** flip the exit code — an account we couldn't reach is a reported gap, not an operation failure.

## Shared flags (both modes)

`--accounts` (default all active), `--regions` (new; default all enabled regions), `--aws_profile_name` (now optional — uses the default credential chain / SSO), `--just_print`.

## Note

The default CF mode now also deletes the management account's stacks (via the current session, consistent with `update_all_stacks.py`); previously it was skipped. This removes the integration completely.

## Testing

- 39 unit tests (stdlib `unittest`, no new dependencies) covering matching/validation, roll-up/plan formatting, scan/delete, the confirmation gate, the summary/exit-code logic (including the operation-failures-only policy and interrupt accounting), CLI arg parsing, and `--accounts` validation.
- Verified end-to-end against a live AWS Organization: dry-run and real delete across a management account (current session) and a sub-account (assume-role). Confirmed the name substring targets only the intended functions and leaves similarly-named ones untouched, CloudFormation-managed functions are always skipped, and the typed confirmation and plan output behave as designed.
- Reviewed across multiple passes.

