### PR TITLE
Detect and delete orphaned CloudFormation lambdas in lambda-only mode

### DIFF
--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -354,19 +354,26 @@ def region_from_stack_id(stack_id):
     return parts[3] or None
 
 
+# Error codes that mean "authorization denied" (permission, SCP, permission
+# boundary). Deliberately excludes transient/credential 403s like ExpiredToken.
+_ACCESS_DENIED_CODES = (
+    "AccessDenied", "AccessDeniedException", "AuthorizationError", "UnauthorizedOperation")
+
+
 def is_access_denied_error(e):
-    """True if the exception is a botocore AccessDenied ClientError. Lets the scan
+    """True if the exception is a botocore authorization-denied ClientError. Lets the scan
     fall back to the pre-orphan-detection behavior (skip CloudFormation-tagged
     functions) when the role simply lacks cloudformation:ListStacks, instead of
     turning every such function into a scan gap and a non-zero exit."""
     response = getattr(e, "response", None)
     if not isinstance(response, dict):
         return False
-    if response.get("Error", {}).get("Code") in ("AccessDenied", "AccessDeniedException"):
-        return True
-    # Catch other authorization denials (SCP / permission-boundary) that surface a
-    # different error code but the same HTTP 403 — still "can't verify", skip clean.
-    return response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 403
+    # Match specific authorization-denial codes only — NOT raw HTTP 403. Transient
+    # credential failures (ExpiredToken/ExpiredTokenException) are also HTTP 403, and
+    # treating those as "role lacks ListStacks" would silently skip CFN-tagged
+    # functions with a clean exit, hiding an incomplete scan. Those must fall through
+    # to the scan-gap path instead.
+    return response.get("Error", {}).get("Code") in _ACCESS_DENIED_CODES
 
 
 def validate_lambda_pattern(pattern):

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -376,9 +376,16 @@ def build_account_rollup(results):
 
 def format_plan_lines(results):
     """One 'account | region | function' line per result, sorted for stable output
-    and easy diffing/grepping of the written plan file."""
-    return [f"{r['account']} | {r['region']} | {r['function']}"
-            for r in sorted(results, key=lambda r: (r["account"], r["region"], r["function"]))]
+    and easy diffing/grepping of the written plan file. Orphaned functions (their
+    CloudFormation stack no longer exists) are annotated so the plan makes the
+    reason for deletion explicit."""
+    lines = []
+    for r in sorted(results, key=lambda r: (r["account"], r["region"], r["function"])):
+        line = f"{r['account']} | {r['region']} | {r['function']}"
+        if r.get("orphaned_stack"):
+            line += f" (orphaned; stack {r['orphaned_stack']} gone)"
+        lines.append(line)
+    return lines
 
 
 LAMBDA_CLIENT_CONFIG = Config(
@@ -502,8 +509,11 @@ def print_lambda_plan(results, skipped_cfn):
     print(color("Lambda functions to delete (per account):", "blue"))
     for account_id, name, count in rollup:
         print(f"  {account_id} ({name})  {count} functions")
-    print(color(
-        f"Total: {len(results)} functions across {len(rollup)} accounts", "blue"))
+    orphan_count = sum(1 for r in results if r.get("orphaned_stack"))
+    total_line = f"Total: {len(results)} functions across {len(rollup)} accounts"
+    if orphan_count:
+        total_line += f" ({orphan_count} orphaned CFN — stack already deleted)"
+    print(color(total_line, "blue"))
     if results:
         print(color("Full list:", "blue"))
         for line in format_plan_lines(results):
@@ -511,7 +521,7 @@ def print_lambda_plan(results, skipped_cfn):
     if skipped_cfn:
         print(color(
             f"Skipped {len(skipped_cfn)} CloudFormation-managed function(s) "
-            f"(not deleted):", "yellow"))
+            f"(live stack, not deleted):", "yellow"))
         for s in sorted(skipped_cfn, key=lambda x: (x["account"], x["region"], x["function"])):
             print(f"  {s['account']} | {s['region']} | {s['function']} "
                   f"(stack: {s['stack']})")
@@ -533,9 +543,13 @@ def print_lambda_summary(deleted, already_gone, failed, skipped_cfn, assume_role
     accounts are reported separately and do NOT affect the exit code (an account
     we merely couldn't reach is a reported gap, not an operation failure)."""
     print(color("=" * 60, "blue"))
+    orphan_deleted = sum(1 for d in deleted if d.get("orphaned_stack"))
+    deleted_part = f"{len(deleted)} deleted"
+    if orphan_deleted:
+        deleted_part += f" ({orphan_deleted} orphaned CFN)"
     print(color(
-        f"Run summary: {len(deleted)} deleted | {len(already_gone)} already gone | "
-        f"{len(failed)} failed | {len(skipped_cfn)} skipped (CFN-managed) | "
+        f"Run summary: {deleted_part} | {len(already_gone)} already gone | "
+        f"{len(failed)} failed | {len(skipped_cfn)} skipped (live CFN stack) | "
         f"{len(assume_role_failures)} accounts unreachable (assume-role failed)", "blue"))
     for r in failed:
         print(color(

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -407,14 +407,18 @@ def list_live_stack_names(sub_account_session, region):
 
 def scan_lambdas_in_region(sub_account_session, region, pattern):
     """List Lambda functions in a region, keep those whose name matches pattern,
-    and split them into (to_delete, skipped_cfn, scan_errors). A function tagged
-    as CloudFormation-managed goes to skipped_cfn with its owning stack name; it
-    is never deleted. list_tags is called only for name-matched functions, and a
-    per-function tag failure never aborts the region scan: the function is left
-    out of to_delete (we can't confirm it isn't CFN-managed, so deleting it would
-    be unsafe) and recorded in scan_errors so the operator sees the gap."""
+    and split them into (to_delete, skipped_cfn, scan_errors). A CloudFormation-
+    tagged function is checked against the region's live stacks: if its stack
+    still exists it is skipped (skipped_cfn, protected); if the stack is gone it
+    is an orphan and goes to to_delete annotated with 'orphaned_stack'. The live-
+    stack set is fetched lazily (only when a CFN-tagged match appears) and cached
+    for the region. If the stack list can't be read, or a function's tags can't
+    be read, the function is left out of to_delete and recorded in scan_errors —
+    we never guess 'delete' when we can't confirm the stack is gone."""
     client = sub_account_session.client("lambda", region_name=region, config=LAMBDA_CLIENT_CONFIG)
     to_delete, skipped_cfn, scan_errors = [], [], []
+    live_stacks = None          # lazily fetched set of live stack names
+    live_stacks_error = None    # set once if listing stacks failed (don't retry)
     for page in client.get_paginator("list_functions").paginate():
         for fn in page["Functions"]:
             name = fn["FunctionName"]
@@ -427,11 +431,26 @@ def scan_lambdas_in_region(sub_account_session, region, pattern):
                     {"region": region, "function": name,
                      "reason": f"could not read tags, left out of plan: {str(e)[:150]}"})
                 continue
-            if is_cfn_managed(tags):
-                skipped_cfn.append(
-                    {"region": region, "function": name, "stack": tags[CFN_STACK_NAME_TAG]})
-            else:
+            if not is_cfn_managed(tags):
                 to_delete.append({"region": region, "function": name})
+                continue
+            stack_name = tags[CFN_STACK_NAME_TAG]
+            if live_stacks is None and live_stacks_error is None:
+                try:
+                    live_stacks = list_live_stack_names(sub_account_session, region)
+                except Exception as e:
+                    live_stacks_error = str(e)[:150]
+            if live_stacks_error is not None:
+                scan_errors.append(
+                    {"region": region, "function": name,
+                     "reason": f"could not list stacks to verify orphan status, "
+                               f"left out of plan: {live_stacks_error}"})
+            elif stack_name in live_stacks:
+                skipped_cfn.append(
+                    {"region": region, "function": name, "stack": stack_name})
+            else:
+                to_delete.append(
+                    {"region": region, "function": name, "orphaned_stack": stack_name})
     return to_delete, skipped_cfn, scan_errors
 
 

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -349,8 +349,11 @@ def _stack_id_parts(stack_id):
     if not stack_id:
         return None
     parts = stack_id.split(":")
-    # arn:aws:cloudformation:<region>:<account>:stack/<name>/<uuid>  -> 6 fields
-    if len(parts) < 6 or parts[0] != "arn" or parts[2] != "cloudformation":
+    # arn:aws:cloudformation:<region>:<account>:stack/<name>/<uuid>  -> 6 fields,
+    # with the resource segment being an actual stack (not e.g. :changeSet/... or a
+    # non-stack resource). Anything else is treated as malformed -> protect.
+    if (len(parts) < 6 or parts[0] != "arn" or parts[2] != "cloudformation"
+            or not parts[5].startswith("stack/")):
         return None
     return parts
 

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -337,7 +337,32 @@ def filter_ll_stacks_from_url(sub_account_session, region, ll_url, return_only_n
 
 
 CFN_STACK_NAME_TAG = "aws:cloudformation:stack-name"
+CFN_STACK_ID_TAG = "aws:cloudformation:stack-id"
 LAMBDA_MIN_PATTERN_LEN = 3
+
+
+def region_from_stack_id(stack_id):
+    """Extract the region from a CloudFormation stack-id ARN
+    ('arn:aws:cloudformation:<region>:<acct>:stack/...'), or None if the id is
+    missing or not a well-formed ARN. Used to verify an orphan's stack in the
+    region that actually owns it rather than assuming the Lambda's own region."""
+    if not stack_id:
+        return None
+    parts = stack_id.split(":")
+    if len(parts) < 4 or parts[0] != "arn":
+        return None
+    return parts[3] or None
+
+
+def is_access_denied_error(e):
+    """True if the exception is a botocore AccessDenied ClientError. Lets the scan
+    fall back to the pre-orphan-detection behavior (skip CloudFormation-tagged
+    functions) when the role simply lacks cloudformation:ListStacks, instead of
+    turning every such function into a scan gap and a non-zero exit."""
+    response = getattr(e, "response", None)
+    if not isinstance(response, dict):
+        return False
+    return response.get("Error", {}).get("Code") in ("AccessDenied", "AccessDeniedException")
 
 
 def validate_lambda_pattern(pattern):
@@ -381,9 +406,12 @@ def format_plan_lines(results):
     reason for deletion explicit."""
     lines = []
     for r in sorted(results, key=lambda r: (r["account"], r["region"], r["function"])):
+        # Keep 'account | region | function' as the first three pipe-delimited
+        # fields so the plan file stays machine-parseable (split on ' | ', take
+        # field 2 for the function name). Orphan context goes in a 4th field.
         line = f"{r['account']} | {r['region']} | {r['function']}"
         if r.get("orphaned_stack"):
-            line += f" (orphaned; stack {r['orphaned_stack']} gone)"
+            line += f" | orphaned (stack {r['orphaned_stack']} gone)"
         lines.append(line)
     return lines
 
@@ -415,17 +443,28 @@ def list_live_stack_names(sub_account_session, region):
 def scan_lambdas_in_region(sub_account_session, region, pattern):
     """List Lambda functions in a region, keep those whose name matches pattern,
     and split them into (to_delete, skipped_cfn, scan_errors). A CloudFormation-
-    tagged function is checked against the region's live stacks: if its stack
-    still exists it is skipped (skipped_cfn, protected); if the stack is gone it
-    is an orphan and goes to to_delete annotated with 'orphaned_stack'. The live-
-    stack set is fetched lazily (only when a CFN-tagged match appears) and cached
-    for the region. If the stack list can't be read, or a function's tags can't
-    be read, the function is left out of to_delete and recorded in scan_errors —
-    we never guess 'delete' when we can't confirm the stack is gone."""
+    tagged function is checked against the live stacks in the region that owns its
+    stack (derived from the stack-id tag): if its stack still exists it is skipped
+    (skipped_cfn, protected); if the stack is gone it is an orphan and goes to
+    to_delete annotated with 'orphaned_stack'.
+
+    Safety rules (we never guess 'delete' when we can't confirm the stack is gone):
+    - A function whose stack lives in another region, or whose stack-id tag is
+      missing/malformed, is protected (skipped_cfn) — we only list THIS region's
+      stacks, so we can't confirm such a stack is gone.
+    - If the role lacks cloudformation:ListStacks (AccessDenied), fall back to the
+      pre-orphan-detection behavior: skip all CFN-tagged functions (skipped_cfn),
+      exit clean — no orphan detection is possible without that permission.
+    - Any other stack-list failure, or a per-function tag-read failure, records a
+      scan gap (scan_errors) and leaves the function out of to_delete.
+
+    The live-stack set is fetched lazily (only when a same-region CFN-tagged match
+    appears) and cached for the region."""
     client = sub_account_session.client("lambda", region_name=region, config=LAMBDA_CLIENT_CONFIG)
     to_delete, skipped_cfn, scan_errors = [], [], []
     live_stacks = None          # lazily fetched set of live stack names
     live_stacks_error = None    # set once if listing stacks failed (don't retry)
+    live_stacks_denied = False  # set once if ListStacks is not permitted (skip, don't gap)
     for page in client.get_paginator("list_functions").paginate():
         for fn in page["Functions"]:
             name = fn["FunctionName"]
@@ -442,12 +481,26 @@ def scan_lambdas_in_region(sub_account_session, region, pattern):
                 to_delete.append({"region": region, "function": name})
                 continue
             stack_name = tags[CFN_STACK_NAME_TAG]
-            if live_stacks is None and live_stacks_error is None:
+            # Only classify orphan status when the stack is owned by THIS region;
+            # otherwise we can't confirm it is gone from this region's stack list,
+            # so protect it.
+            if region_from_stack_id(tags.get(CFN_STACK_ID_TAG)) != region:
+                skipped_cfn.append(
+                    {"region": region, "function": name, "stack": stack_name})
+                continue
+            if live_stacks is None and live_stacks_error is None and not live_stacks_denied:
                 try:
                     live_stacks = list_live_stack_names(sub_account_session, region)
                 except Exception as e:
-                    live_stacks_error = str(e)[:150]
-            if live_stacks_error is not None:
+                    if is_access_denied_error(e):
+                        live_stacks_denied = True
+                    else:
+                        live_stacks_error = str(e)[:150]
+            if live_stacks_denied:
+                # No permission to verify — behave as before orphan detection existed.
+                skipped_cfn.append(
+                    {"region": region, "function": name, "stack": stack_name})
+            elif live_stacks_error is not None:
                 scan_errors.append(
                     {"region": region, "function": name,
                      "reason": f"could not list stacks to verify orphan status, "

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -362,7 +362,11 @@ def is_access_denied_error(e):
     response = getattr(e, "response", None)
     if not isinstance(response, dict):
         return False
-    return response.get("Error", {}).get("Code") in ("AccessDenied", "AccessDeniedException")
+    if response.get("Error", {}).get("Code") in ("AccessDenied", "AccessDeniedException"):
+        return True
+    # Catch other authorization denials (SCP / permission-boundary) that surface a
+    # different error code but the same HTTP 403 — still "can't verify", skip clean.
+    return response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 403
 
 
 def validate_lambda_pattern(pattern):
@@ -481,6 +485,13 @@ def scan_lambdas_in_region(sub_account_session, region, pattern):
                 to_delete.append({"region": region, "function": name})
                 continue
             stack_name = tags[CFN_STACK_NAME_TAG]
+            if not stack_name:
+                # CFN-managed (tag present) but the stack-name value is empty, so we
+                # can't identify the owning stack. Protect it rather than fall through
+                # and delete it as if it had no CloudFormation tag at all.
+                skipped_cfn.append(
+                    {"region": region, "function": name, "stack": stack_name})
+                continue
             # Only classify orphan status when the stack is owned by THIS region;
             # otherwise we can't confirm it is gone from this region's stack list,
             # so protect it.
@@ -574,7 +585,7 @@ def print_lambda_plan(results, skipped_cfn):
     if skipped_cfn:
         print(color(
             f"Skipped {len(skipped_cfn)} CloudFormation-managed function(s) "
-            f"(live stack, not deleted):", "yellow"))
+            f"(not deleted):", "yellow"))
         for s in sorted(skipped_cfn, key=lambda x: (x["account"], x["region"], x["function"])):
             print(f"  {s['account']} | {s['region']} | {s['function']} "
                   f"(stack: {s['stack']})")
@@ -602,7 +613,7 @@ def print_lambda_summary(deleted, already_gone, failed, skipped_cfn, assume_role
         deleted_part += f" ({orphan_deleted} orphaned CFN)"
     print(color(
         f"Run summary: {deleted_part} | {len(already_gone)} already gone | "
-        f"{len(failed)} failed | {len(skipped_cfn)} skipped (live CFN stack) | "
+        f"{len(failed)} failed | {len(skipped_cfn)} skipped (CFN-managed) | "
         f"{len(assume_role_failures)} accounts unreachable (assume-role failed)", "blue"))
     for r in failed:
         print(color(

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -341,17 +341,35 @@ CFN_STACK_ID_TAG = "aws:cloudformation:stack-id"
 LAMBDA_MIN_PATTERN_LEN = 3
 
 
-def region_from_stack_id(stack_id):
-    """Extract the region from a CloudFormation stack-id ARN
-    ('arn:aws:cloudformation:<region>:<acct>:stack/...'), or None if the id is
-    missing or not a well-formed ARN. Used to verify an orphan's stack in the
-    region that actually owns it rather than assuming the Lambda's own region."""
+def _stack_id_parts(stack_id):
+    """Split a CloudFormation stack-id ARN into its fields, or None if it is
+    missing or not a well-formed cloudformation ARN. Requires the service segment
+    to be 'cloudformation' so a stray non-CFN ARN (e.g. arn:aws:lambda:...) is not
+    mistaken for a stack reference."""
     if not stack_id:
         return None
     parts = stack_id.split(":")
-    if len(parts) < 4 or parts[0] != "arn":
+    # arn:aws:cloudformation:<region>:<account>:stack/<name>/<uuid>  -> 6 fields
+    if len(parts) < 6 or parts[0] != "arn" or parts[2] != "cloudformation":
         return None
-    return parts[3] or None
+    return parts
+
+
+def region_from_stack_id(stack_id):
+    """Region from a CloudFormation stack-id ARN, or None if missing/malformed.
+    Used to verify an orphan's stack in the region that actually owns it rather
+    than assuming the Lambda's own region."""
+    parts = _stack_id_parts(stack_id)
+    return (parts[3] or None) if parts else None
+
+
+def account_from_stack_id(stack_id):
+    """Account id from a CloudFormation stack-id ARN, or None if missing/malformed.
+    Used together with the region so a stack-id pointing at a DIFFERENT account is
+    never treated as owned by the account being scanned (which would list the wrong
+    account's stacks and could misclassify a live-stack Lambda as an orphan)."""
+    parts = _stack_id_parts(stack_id)
+    return (parts[4] or None) if parts else None
 
 
 # CloudFormation ListStacks surfaces authorization denials (IAM, SCP, permission
@@ -392,8 +410,11 @@ def lambda_name_matches(function_name, pattern):
 
 
 def is_cfn_managed(tags):
-    """True if the Lambda's tags mark it as CloudFormation-managed."""
-    return CFN_STACK_NAME_TAG in (tags or {})
+    """True if the Lambda's tags mark it as CloudFormation-managed. Either the
+    stack-name or the stack-id tag counts, so a function carrying only a stack-id
+    is not mistaken for a plain (non-CFN) function and deleted unconditionally."""
+    tags = tags or {}
+    return CFN_STACK_NAME_TAG in tags or CFN_STACK_ID_TAG in tags
 
 
 def build_account_rollup(results):
@@ -451,26 +472,27 @@ def list_live_stack_names(sub_account_session, region):
     return live
 
 
-def scan_lambdas_in_region(sub_account_session, region, pattern):
+def scan_lambdas_in_region(sub_account_session, region, pattern, account_id):
     """List Lambda functions in a region, keep those whose name matches pattern,
     and split them into (to_delete, skipped_cfn, scan_errors). A CloudFormation-
-    tagged function is checked against the live stacks in the region that owns its
-    stack (derived from the stack-id tag): if its stack still exists it is skipped
-    (skipped_cfn, protected); if the stack is gone it is an orphan and goes to
-    to_delete annotated with 'orphaned_stack'.
+    tagged function is checked against the live stacks in the region/account that
+    own its stack (derived from the stack-id tag): if its stack still exists it is
+    skipped (skipped_cfn, protected); if the stack is gone it is an orphan and goes
+    to to_delete annotated with 'orphaned_stack'.
 
     Safety rules (we never guess 'delete' when we can't confirm the stack is gone):
-    - A function whose stack lives in another region, or whose stack-id tag is
-      missing/malformed, is protected (skipped_cfn) — we only list THIS region's
-      stacks, so we can't confirm such a stack is gone.
+    - A function whose stack lives in another region OR another account, or whose
+      stack-id tag is missing/malformed, is protected (skipped_cfn) — we only list
+      THIS account/region's stacks, so we can't confirm such a stack is gone.
     - If the role lacks cloudformation:ListStacks (AccessDenied), fall back to the
       pre-orphan-detection behavior: skip all CFN-tagged functions (skipped_cfn),
-      exit clean — no orphan detection is possible without that permission.
+      exit clean — no orphan detection is possible without that permission — and
+      print a warning so the operator knows detection was skipped for this region.
     - Any other stack-list failure, or a per-function tag-read failure, records a
       scan gap (scan_errors) and leaves the function out of to_delete.
 
-    The live-stack set is fetched lazily (only when a same-region CFN-tagged match
-    appears) and cached for the region."""
+    The live-stack set is fetched lazily (only when a same-account/region CFN-tagged
+    match appears) and cached for the region."""
     client = sub_account_session.client("lambda", region_name=region, config=LAMBDA_CLIENT_CONFIG)
     to_delete, skipped_cfn, scan_errors = [], [], []
     live_stacks = None          # lazily fetched set of live stack names
@@ -491,18 +513,20 @@ def scan_lambdas_in_region(sub_account_session, region, pattern):
             if not is_cfn_managed(tags):
                 to_delete.append({"region": region, "function": name})
                 continue
-            stack_name = tags[CFN_STACK_NAME_TAG]
+            stack_name = tags.get(CFN_STACK_NAME_TAG)
             if not stack_name:
-                # CFN-managed (tag present) but the stack-name value is empty, so we
-                # can't identify the owning stack. Protect it rather than fall through
-                # and delete it as if it had no CloudFormation tag at all.
+                # CFN-managed (a CFN tag is present) but the stack-name value is
+                # empty or absent, so we can't identify the owning stack. Protect it
+                # rather than fall through and delete it as if it had no CFN tag.
                 skipped_cfn.append(
-                    {"region": region, "function": name, "stack": stack_name})
+                    {"region": region, "function": name, "stack": stack_name or ""})
                 continue
-            # Only classify orphan status when the stack is owned by THIS region;
-            # otherwise we can't confirm it is gone from this region's stack list,
-            # so protect it.
-            if region_from_stack_id(tags.get(CFN_STACK_ID_TAG)) != region:
+            # Only classify orphan status when the stack is owned by THIS account AND
+            # region; otherwise we would be listing the wrong account/region's stacks
+            # and could not confirm the stack is gone, so protect it.
+            stack_id = tags.get(CFN_STACK_ID_TAG)
+            if (region_from_stack_id(stack_id) != region
+                    or account_from_stack_id(stack_id) != account_id):
                 skipped_cfn.append(
                     {"region": region, "function": name, "stack": stack_name})
                 continue
@@ -512,6 +536,11 @@ def scan_lambdas_in_region(sub_account_session, region, pattern):
                 except Exception as e:
                     if is_access_denied_error(e):
                         live_stacks_denied = True
+                        print(color(
+                            f"Account: {account_id} | {region}: cloudformation:ListStacks "
+                            f"denied — orphan detection SKIPPED here; CFN-tagged functions "
+                            f"are reported as skipped (not evaluated). Grant "
+                            f"cloudformation:ListStacks to detect orphans.", "yellow"))
                     else:
                         live_stacks_error = str(e)[:150]
             if live_stacks_denied:
@@ -567,8 +596,10 @@ def confirm_deletion(total, account_count, isatty_fn, input_fn):
 
 
 def write_plan_file(results, path):
-    """Write the full delete plan (one 'account | region | function' per line) to
-    path so it can be grepped, diffed, shared, and kept as an audit record."""
+    """Write the full delete plan to path so it can be grepped, diffed, shared, and
+    kept as an audit record. Each line is 'account | region | function', with an
+    optional 4th '| orphaned (...)' field for orphaned functions; splitting on
+    ' | ' and taking field 2 always yields the bare function name."""
     with open(path, "w") as f:
         f.write("\n".join(format_plan_lines(results)) + "\n")
 

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -354,10 +354,10 @@ def region_from_stack_id(stack_id):
     return parts[3] or None
 
 
-# Error codes that mean "authorization denied" (permission, SCP, permission
-# boundary). Deliberately excludes transient/credential 403s like ExpiredToken.
-_ACCESS_DENIED_CODES = (
-    "AccessDenied", "AccessDeniedException", "AuthorizationError", "UnauthorizedOperation")
+# CloudFormation ListStacks surfaces authorization denials (IAM, SCP, permission
+# boundary) as AccessDenied. Deliberately excludes transient/credential 403s like
+# ExpiredToken (those must fall through to the scan-gap path, not skip clean).
+_ACCESS_DENIED_CODES = ("AccessDenied", "AccessDeniedException")
 
 
 def is_access_denied_error(e):

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -494,6 +494,7 @@ def scan_lambdas_in_region(sub_account_session, region, pattern, account_id):
     The live-stack set is fetched lazily (only when a same-account/region CFN-tagged
     match appears) and cached for the region."""
     client = sub_account_session.client("lambda", region_name=region, config=LAMBDA_CLIENT_CONFIG)
+    account_id = str(account_id)   # compare like-for-like against the ARN's account field
     to_delete, skipped_cfn, scan_errors = [], [], []
     live_stacks = None          # lazily fetched set of live stack names
     live_stacks_error = None    # set once if listing stacks failed (don't retry)
@@ -519,7 +520,8 @@ def scan_lambdas_in_region(sub_account_session, region, pattern, account_id):
                 # empty or absent, so we can't identify the owning stack. Protect it
                 # rather than fall through and delete it as if it had no CFN tag.
                 skipped_cfn.append(
-                    {"region": region, "function": name, "stack": stack_name or ""})
+                    {"region": region, "function": name,
+                     "stack": "unknown - stack-id tag only"})
                 continue
             # Only classify orphan status when the stack is owned by THIS account AND
             # region; otherwise we would be listing the wrong account/region's stacks

--- a/src/python/common/boto_common.py
+++ b/src/python/common/boto_common.py
@@ -388,6 +388,23 @@ LAMBDA_CLIENT_CONFIG = Config(
 )
 
 
+def list_live_stack_names(sub_account_session, region):
+    """Return the set of CloudFormation stack names that currently exist (any
+    status except DELETE_COMPLETE) in the region. Used to tell a live
+    CloudFormation-managed Lambda from an orphan whose stack was already deleted.
+    Raises on API failure so the caller can treat the region's stack state as
+    unknown and skip rather than guess. Reuses LAMBDA_CLIENT_CONFIG only for its
+    adaptive-retry/timeout settings (not Lambda-specific)."""
+    client = sub_account_session.client(
+        "cloudformation", region_name=region, config=LAMBDA_CLIENT_CONFIG)
+    live = set()
+    for page in client.get_paginator("list_stacks").paginate():
+        for s in page["StackSummaries"]:
+            if s["StackStatus"] != "DELETE_COMPLETE":
+                live.add(s["StackName"])
+    return live
+
+
 def scan_lambdas_in_region(sub_account_session, region, pattern):
     """List Lambda functions in a region, keep those whose name matches pattern,
     and split them into (to_delete, skipped_cfn, scan_errors). A function tagged

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -61,9 +61,12 @@ def build_arg_parser():
     parser.add_argument(
         "--lambda_name_contains",
         help="LAMBDA-ONLY MODE: delete only Lambda functions whose name contains this "
-        "string (case-insensitive, min 3 chars). Does NOT touch CloudFormation stacks and "
-        "does NOT remove the Stream Security integration. Mutually exclusive with the "
-        "stack-only flags.", required=False)
+        "string (case-insensitive, min 3 chars). Deletes only functions whose "
+        "CloudFormation stack no longer exists (orphans); functions owned by a live "
+        "stack are skipped. Requires cloudformation:ListStacks in each target account/"
+        "region to detect orphans (without it, all CFN-tagged functions are skipped). "
+        "Does NOT touch CloudFormation stacks or remove the Stream Security integration. "
+        "Mutually exclusive with the stack-only flags.", required=False)
     return parser
 
 
@@ -106,7 +109,8 @@ def _scan_account_lambdas(sub_account, session, regions, pattern):
     session.client("cloudformation", region_name=regions[0]).get_paginator("list_stacks")
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
         future_to_region = {
-            executor.submit(scan_lambdas_in_region, session, region, pattern): region
+            executor.submit(scan_lambdas_in_region, session, region, pattern,
+                            sub_account[0]): region
             for region in regions}
         for future in concurrent.futures.as_completed(future_to_region):
             region = future_to_region[future]
@@ -144,10 +148,10 @@ def _reverify_orphans(session, account_id, items, failed):
     Orphans we can no longer verify are appended to `failed` (a real gap that drives
     a non-zero exit) so they are never deleted on an unverified guess.
 
-    Relies on the scan-time invariant that an orphan's region equals its stack's
-    owning region (scan_lambdas_in_region only classifies an orphan when
-    region_from_stack_id(stack) == the scan region), so re-listing by it["region"]
-    checks the correct region."""
+    Relies on the scan-time invariant that an orphan's region AND account equal its
+    stack's owning region/account (scan_lambdas_in_region only classifies an orphan
+    when both the stack-id region and account match the scanned account/region), so
+    re-listing this account's stacks by it["region"] checks the correct place."""
     orphan_regions = {it["region"] for it in items if it.get("orphaned_stack")}
     if not orphan_regions:
         return items, []
@@ -161,7 +165,7 @@ def _reverify_orphans(session, account_id, items, failed):
             live_now[rg] = None
             print(color(f"Account: {account_id} | Could not re-list stacks in {rg} to "
                         f"re-verify orphans; those are recorded as failed (not deleted): "
-                        f"{e}", "yellow"))
+                        f"{str(e)[:150]}", "yellow"))
     kept, reprotected = [], []
     for it in items:
         stack = it.get("orphaned_stack")

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -131,11 +131,18 @@ def _scan_account_lambdas(sub_account, session, regions, pattern):
 def _reverify_orphans(session, account_id, items, failed):
     """Guard against a scan→delete race: an orphan classified because its stack was
     gone at scan time could have had that stack recreated before this delete phase
-    reached it. Re-list the live stacks (per region) for this account's orphans and
-    drop any whose stack came back, or any we can no longer verify, recording each
-    in `failed` (a real miss that drives a non-zero exit) so it is never deleted.
-    Non-orphan items (no CloudFormation tag) pass through untouched. Returns the
-    list of items that are still safe to delete.
+    reached it. Re-list the live stacks (per region) for this account's orphans and,
+    for each orphan, either keep it (still gone), re-protect it (stack came back), or
+    fail it (couldn't re-verify). Non-orphan items (no CloudFormation tag) pass
+    through untouched.
+
+    Returns (kept, reprotected):
+      - kept:        still safe to delete (stack confirmed still gone) + non-orphans.
+      - reprotected: stack exists again — a CORRECT protection, not an operation
+                     failure, so it is reported as skipped and does NOT drive a
+                     non-zero exit.
+    Orphans we can no longer verify are appended to `failed` (a real gap that drives
+    a non-zero exit) so they are never deleted on an unverified guess.
 
     Relies on the scan-time invariant that an orphan's region equals its stack's
     owning region (scan_lambdas_in_region only classifies an orphan when
@@ -143,17 +150,19 @@ def _reverify_orphans(session, account_id, items, failed):
     checks the correct region."""
     orphan_regions = {it["region"] for it in items if it.get("orphaned_stack")}
     if not orphan_regions:
-        return items
+        return items, []
     live_now = {}
     for rg in orphan_regions:
         try:
             live_now[rg] = list_live_stack_names(session, rg)
         except Exception as e:
-            # Can't re-verify — refuse to delete this region's orphans (safe default).
+            # Can't re-verify — refuse to delete this region's orphans (safe default),
+            # and record them as failed (a real gap), matching the bookkeeping below.
             live_now[rg] = None
             print(color(f"Account: {account_id} | Could not re-list stacks in {rg} to "
-                        f"re-verify orphans; those will be skipped: {e}", "yellow"))
-    kept = []
+                        f"re-verify orphans; those are recorded as failed (not deleted): "
+                        f"{e}", "yellow"))
+    kept, reprotected = [], []
     for it in items:
         stack = it.get("orphaned_stack")
         if not stack:
@@ -165,12 +174,12 @@ def _reverify_orphans(session, account_id, items, failed):
                                           "delete time - not deleted"))
         elif stack in live:
             print(color(f"Account: {account_id} | Stack {stack} exists again - NOT "
-                        f"deleting {it['function']} ({it['region']})", "yellow"))
-            failed.append(dict(it, reason=f"stack {stack} was recreated during the run "
-                                          f"- not deleted"))
+                        f"deleting {it['function']} ({it['region']}) (protected, not a "
+                        f"failure)", "yellow"))
+            reprotected.append(it)
         else:
             kept.append(it)
-    return kept
+    return kept, reprotected
 
 
 def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
@@ -271,7 +280,7 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
         return early
 
     # Delete phase - re-assume roles fresh (the scan can outlive 1h STS creds)
-    deleted, already_gone, failed = [], [], []
+    deleted, already_gone, failed, reprotected = [], [], [], []
     interrupted = False
     by_account = {}
     for d in all_to_delete:
@@ -300,7 +309,8 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                 # Lambda whose stack came back. Single-threaded, before the pool, and
                 # inside this try so an unexpected error here can't crash the whole
                 # run — the except below records this account's items as failed.
-                items = _reverify_orphans(session, account_id, items, failed)
+                items, reprotected_now = _reverify_orphans(session, account_id, items, failed)
+                reprotected.extend(reprotected_now)
                 if not items:
                     continue
                 # Warm the session's client-creation caches single-threaded; boto3
@@ -354,7 +364,7 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
     # was interrupted before reaching them), so an aborted run isn't mistaken for
     # a completed one.
     attempted = {(x["account"], x["region"], x["function"])
-                 for x in deleted + already_gone + failed}
+                 for x in deleted + already_gone + failed + reprotected}
     not_attempted = [x for x in all_to_delete
                      if (x["account"], x["region"], x["function"]) not in attempted]
     if not_attempted:
@@ -362,8 +372,14 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                     f"(run interrupted before reaching them); re-run to finish them.",
                     "yellow"))
 
+    if reprotected:
+        print(color(f"{len(reprotected)} planned function(s) were protected at delete "
+                    f"time (their CloudFormation stack was recreated) - not deleted, not "
+                    f"a failure.", "yellow"))
+    # Re-protected functions are now CloudFormation-managed again, so they count as
+    # skipped (not failures) and do not drive a non-zero exit.
     rc = print_lambda_summary(deleted, already_gone, failed + all_scan_errors,
-                              all_skipped, assume_role_failures)
+                              all_skipped + reprotected, assume_role_failures)
     # An interrupted run left work undone — never report it as a clean success.
     return max(rc, 1) if interrupted else rc
 

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -96,8 +96,11 @@ def _scan_account_lambdas(sub_account, session, regions, pattern):
             item.update({"account": sub_account[0], "name": sub_account[1]})
 
     # Warm the session's client-creation caches single-threaded; boto3 Session
-    # is not thread-safe for concurrent first-time client creation.
+    # is not thread-safe for concurrent first-time client creation. The region
+    # threads below create both a lambda client (the scan) and a cloudformation
+    # client (the orphan stack-existence check), so warm both services here.
     session.client("lambda", region_name=regions[0])
+    session.client("cloudformation", region_name=regions[0])
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
         future_to_region = {
             executor.submit(scan_lambdas_in_region, session, region, pattern): region

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -132,7 +132,12 @@ def _reverify_orphans(session, account_id, items, failed):
     drop any whose stack came back, or any we can no longer verify, recording each
     in `failed` (a real miss that drives a non-zero exit) so it is never deleted.
     Non-orphan items (no CloudFormation tag) pass through untouched. Returns the
-    list of items that are still safe to delete."""
+    list of items that are still safe to delete.
+
+    Relies on the scan-time invariant that an orphan's region equals its stack's
+    owning region (scan_lambdas_in_region only classifies an orphan when
+    region_from_stack_id(stack) == the scan region), so re-listing by it["region"]
+    checks the correct region."""
     orphan_regions = {it["region"] for it in items if it.get("orphaned_stack")}
     if not orphan_regions:
         return items
@@ -285,14 +290,16 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                     failed.append(dict(it, reason=f"delete skipped - could not assume "
                                                   f"role: {str(e)[:120]}"))
                 continue
-            # Re-verify orphans before deleting: a stack could have been (re)created
-            # between the scan and now (the delete phase re-assumes roles because the
-            # scan can outlive 1h STS creds). Never delete a Lambda whose stack came
-            # back. This runs single-threaded, before the delete pool below.
-            items = _reverify_orphans(session, account_id, items, failed)
-            if not items:
-                continue
             try:
+                # Re-verify orphans before deleting: a stack could have been
+                # (re)created between the scan and now (the delete phase re-assumes
+                # roles because the scan can outlive 1h STS creds). Never delete a
+                # Lambda whose stack came back. Single-threaded, before the pool, and
+                # inside this try so an unexpected error here can't crash the whole
+                # run — the except below records this account's items as failed.
+                items = _reverify_orphans(session, account_id, items, failed)
+                if not items:
+                    continue
                 # Warm the session's client-creation caches single-threaded; boto3
                 # Session is not thread-safe for concurrent first-time client creation.
                 session.client("lambda", region_name=items[0]["region"])

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -60,13 +60,14 @@ def build_arg_parser():
     # Lambda-only mode
     parser.add_argument(
         "--lambda_name_contains",
-        help="LAMBDA-ONLY MODE: delete only Lambda functions whose name contains this "
-        "string (case-insensitive, min 3 chars). Deletes only functions whose "
-        "CloudFormation stack no longer exists (orphans); functions owned by a live "
-        "stack are skipped. Requires cloudformation:ListStacks in each target account/"
-        "region to detect orphans (without it, all CFN-tagged functions are skipped). "
-        "Does NOT touch CloudFormation stacks or remove the Stream Security integration. "
-        "Mutually exclusive with the stack-only flags.", required=False)
+        help="LAMBDA-ONLY MODE: delete Lambda functions whose name contains this string "
+        "(case-insensitive, min 3 chars). Deletes matching functions that are NOT owned "
+        "by a live CloudFormation stack — i.e. functions with no CloudFormation tag, plus "
+        "orphaned functions whose stack no longer exists; functions owned by a live stack "
+        "are skipped. Requires cloudformation:ListStacks in each target account/region to "
+        "detect orphans (without it, all CFN-tagged functions are skipped). Does NOT touch "
+        "CloudFormation stacks or remove the Stream Security integration. Mutually exclusive "
+        "with the stack-only flags.", required=False)
     return parser
 
 

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -100,7 +100,10 @@ def _scan_account_lambdas(sub_account, session, regions, pattern):
     # threads below create both a lambda client (the scan) and a cloudformation
     # client (the orphan stack-existence check), so warm both services here.
     session.client("lambda", region_name=regions[0])
-    session.client("cloudformation", region_name=regions[0])
+    # Also force the cloudformation client AND its list_stacks paginator model to
+    # load single-threaded here — the orphan check calls get_paginator inside the
+    # region threads, and first-loading the paginator config concurrently races.
+    session.client("cloudformation", region_name=regions[0]).get_paginator("list_stacks")
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
         future_to_region = {
             executor.submit(scan_lambdas_in_region, session, region, pattern): region

--- a/src/python/utilities/organization_delete_integration.py
+++ b/src/python/utilities/organization_delete_integration.py
@@ -125,6 +125,46 @@ def _scan_account_lambdas(sub_account, session, regions, pattern):
     return to_delete, skipped, scan_errors
 
 
+def _reverify_orphans(session, account_id, items, failed):
+    """Guard against a scan→delete race: an orphan classified because its stack was
+    gone at scan time could have had that stack recreated before this delete phase
+    reached it. Re-list the live stacks (per region) for this account's orphans and
+    drop any whose stack came back, or any we can no longer verify, recording each
+    in `failed` (a real miss that drives a non-zero exit) so it is never deleted.
+    Non-orphan items (no CloudFormation tag) pass through untouched. Returns the
+    list of items that are still safe to delete."""
+    orphan_regions = {it["region"] for it in items if it.get("orphaned_stack")}
+    if not orphan_regions:
+        return items
+    live_now = {}
+    for rg in orphan_regions:
+        try:
+            live_now[rg] = list_live_stack_names(session, rg)
+        except Exception as e:
+            # Can't re-verify — refuse to delete this region's orphans (safe default).
+            live_now[rg] = None
+            print(color(f"Account: {account_id} | Could not re-list stacks in {rg} to "
+                        f"re-verify orphans; those will be skipped: {e}", "yellow"))
+    kept = []
+    for it in items:
+        stack = it.get("orphaned_stack")
+        if not stack:
+            kept.append(it)
+            continue
+        live = live_now.get(it["region"])
+        if live is None:
+            failed.append(dict(it, reason="could not re-verify stack still gone at "
+                                          "delete time - not deleted"))
+        elif stack in live:
+            print(color(f"Account: {account_id} | Stack {stack} exists again - NOT "
+                        f"deleting {it['function']} ({it['region']})", "yellow"))
+            failed.append(dict(it, reason=f"stack {stack} was recreated during the run "
+                                          f"- not deleted"))
+        else:
+            kept.append(it)
+    return kept
+
+
 def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                      pattern, just_print):
     pattern = validate_lambda_pattern(pattern)
@@ -244,6 +284,13 @@ def _run_lambda_mode(sub_accounts, sts_client, management_account_id, regions,
                 for it in items:
                     failed.append(dict(it, reason=f"delete skipped - could not assume "
                                                   f"role: {str(e)[:120]}"))
+                continue
+            # Re-verify orphans before deleting: a stack could have been (re)created
+            # between the scan and now (the delete phase re-assumes roles because the
+            # scan can outlive 1h STS creds). Never delete a Lambda whose stack came
+            # back. This runs single-threaded, before the delete pool below.
+            items = _reverify_orphans(session, account_id, items, failed)
+            if not items:
                 continue
             try:
                 # Warm the session's client-creation caches single-threaded; boto3

--- a/tests/test_delete_integration_lambda_scan.py
+++ b/tests/test_delete_integration_lambda_scan.py
@@ -71,6 +71,7 @@ class TestReverifyWiredIntoRun(unittest.TestCase):
                 patch.object(mod, "_reverify_orphans", wraps=mod._reverify_orphans) as spy, \
                 patch.object(mod, "delete_lambda_function",
                              side_effect=lambda s, r, f: deleted.append(f) or "deleted"), \
+                patch.object(mod, "write_plan_file"), \
                 patch.object(mod, "list_live_stack_names", **list_kwargs):
             with contextlib.redirect_stdout(io.StringIO()):
                 rc = mod._run_lambda_mode(accounts, sts_client=None,
@@ -130,6 +131,7 @@ class TestLambdaScanErrorsAffectExit(unittest.TestCase):
 
         with patch.object(mod, "_session_for_account", return_value=object()), \
                 patch.object(mod, "_scan_account_lambdas", side_effect=fake_scan), \
+                patch.object(mod, "write_plan_file"), \
                 patch.object(mod.sys.stdin, "isatty", return_value=False):
             # just_print=False so it reaches confirm_deletion, which refuses on the
             # non-TTY stdin — the run must NOT report success.
@@ -175,6 +177,7 @@ class TestLambdaScanErrorsAffectExit(unittest.TestCase):
         with patch.object(mod, "_session_for_account", side_effect=fake_session), \
                 patch.object(mod, "_scan_account_lambdas", side_effect=fake_scan), \
                 patch.object(mod, "confirm_deletion", return_value=True), \
+                patch.object(mod, "write_plan_file"), \
                 contextlib.redirect_stdout(buf):
             rc = mod._run_lambda_mode(accounts, sts_client=None, management_account_id="999",
                                       regions=["us-east-1"], pattern="target", just_print=False)

--- a/tests/test_delete_integration_lambda_scan.py
+++ b/tests/test_delete_integration_lambda_scan.py
@@ -52,6 +52,45 @@ class TestReverifyOrphans(unittest.TestCase):
         lls.assert_not_called()
 
 
+class TestReverifyWiredIntoRun(unittest.TestCase):
+    """_reverify_orphans is exercised in isolation elsewhere; these confirm
+    _run_lambda_mode actually calls it and that its outcomes drive the exit code."""
+
+    def _run(self, list_kwargs):
+        accounts = [("111", "acct-a")]
+        orphan = {"account": "111", "name": "acct-a", "region": "us-east-1",
+                  "function": "orph", "orphaned_stack": "dead"}
+
+        def fake_scan(sub_account, session, regions, pattern):
+            return [dict(orphan)], [], []
+
+        deleted = []
+        with patch.object(mod, "_session_for_account", return_value=object()), \
+                patch.object(mod, "_scan_account_lambdas", side_effect=fake_scan), \
+                patch.object(mod, "confirm_deletion", return_value=True), \
+                patch.object(mod, "_reverify_orphans", wraps=mod._reverify_orphans) as spy, \
+                patch.object(mod, "delete_lambda_function",
+                             side_effect=lambda s, r, f: deleted.append(f) or "deleted"), \
+                patch.object(mod, "list_live_stack_names", **list_kwargs):
+            with contextlib.redirect_stdout(io.StringIO()):
+                rc = mod._run_lambda_mode(accounts, sts_client=None,
+                                          management_account_id="999",
+                                          regions=["us-east-1"], pattern="orph",
+                                          just_print=False)
+        spy.assert_called()          # the delete phase is wired to call _reverify_orphans
+        return rc, deleted
+
+    def test_recreated_stack_orphan_not_deleted_exit_zero(self):
+        rc, deleted = self._run({"return_value": {"dead"}})   # stack came back
+        self.assertEqual(deleted, [])          # protected, not deleted
+        self.assertEqual(rc, 0)                # correct protection -> clean exit
+
+    def test_unverifiable_orphan_not_deleted_exit_nonzero(self):
+        rc, deleted = self._run({"side_effect": RuntimeError("boom")})
+        self.assertEqual(deleted, [])          # not deleted
+        self.assertNotEqual(rc, 0)             # a real gap -> non-zero exit
+
+
 class TestLambdaScanErrorsAffectExit(unittest.TestCase):
     def test_scan_gap_causes_nonzero_exit_even_on_just_print(self):
         accounts = [("111", "acct-a")]

--- a/tests/test_delete_integration_lambda_scan.py
+++ b/tests/test_delete_integration_lambda_scan.py
@@ -9,6 +9,45 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from src.python.utilities import organization_delete_integration as mod
 
 
+class TestReverifyOrphans(unittest.TestCase):
+    def _items(self):
+        return [
+            {"account": "111", "name": "a", "region": "us-east-1", "function": "plain"},
+            {"account": "111", "name": "a", "region": "us-east-1", "function": "orph",
+             "orphaned_stack": "dead"},
+        ]
+
+    def test_orphan_still_gone_is_kept_nonorphan_passthrough(self):
+        failed = []
+        with patch.object(mod, "list_live_stack_names", return_value={"other"}):
+            kept = mod._reverify_orphans(object(), "111", self._items(), failed)
+        self.assertEqual({k["function"] for k in kept}, {"plain", "orph"})
+        self.assertEqual(failed, [])
+
+    def test_recreated_stack_orphan_is_dropped_and_failed(self):
+        failed = []
+        with patch.object(mod, "list_live_stack_names", return_value={"dead"}):
+            kept = mod._reverify_orphans(object(), "111", self._items(), failed)
+        self.assertEqual([k["function"] for k in kept], ["plain"])
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["function"], "orph")
+
+    def test_unverifiable_orphan_is_dropped_and_failed(self):
+        failed = []
+        with patch.object(mod, "list_live_stack_names", side_effect=RuntimeError("boom")):
+            kept = mod._reverify_orphans(object(), "111", self._items(), failed)
+        self.assertEqual([k["function"] for k in kept], ["plain"])
+        self.assertEqual(len(failed), 1)
+
+    def test_no_orphans_returns_items_unchanged_without_listing(self):
+        failed = []
+        items = [{"account": "111", "name": "a", "region": "us-east-1", "function": "plain"}]
+        with patch.object(mod, "list_live_stack_names") as lls:
+            kept = mod._reverify_orphans(object(), "111", items, failed)
+        self.assertEqual(kept, items)
+        lls.assert_not_called()
+
+
 class TestLambdaScanErrorsAffectExit(unittest.TestCase):
     def test_scan_gap_causes_nonzero_exit_even_on_just_print(self):
         accounts = [("111", "acct-a")]

--- a/tests/test_delete_integration_lambda_scan.py
+++ b/tests/test_delete_integration_lambda_scan.py
@@ -20,31 +20,35 @@ class TestReverifyOrphans(unittest.TestCase):
     def test_orphan_still_gone_is_kept_nonorphan_passthrough(self):
         failed = []
         with patch.object(mod, "list_live_stack_names", return_value={"other"}):
-            kept = mod._reverify_orphans(object(), "111", self._items(), failed)
+            kept, reprotected = mod._reverify_orphans(object(), "111", self._items(), failed)
         self.assertEqual({k["function"] for k in kept}, {"plain", "orph"})
+        self.assertEqual(reprotected, [])
         self.assertEqual(failed, [])
 
-    def test_recreated_stack_orphan_is_dropped_and_failed(self):
+    def test_recreated_stack_orphan_is_reprotected_not_failed(self):
+        # Stack came back -> a correct protection, NOT an operation failure.
         failed = []
         with patch.object(mod, "list_live_stack_names", return_value={"dead"}):
-            kept = mod._reverify_orphans(object(), "111", self._items(), failed)
+            kept, reprotected = mod._reverify_orphans(object(), "111", self._items(), failed)
         self.assertEqual([k["function"] for k in kept], ["plain"])
-        self.assertEqual(len(failed), 1)
-        self.assertEqual(failed[0]["function"], "orph")
+        self.assertEqual([r["function"] for r in reprotected], ["orph"])
+        self.assertEqual(failed, [])            # not a failure -> no non-zero exit
 
-    def test_unverifiable_orphan_is_dropped_and_failed(self):
+    def test_unverifiable_orphan_is_failed_not_reprotected(self):
         failed = []
         with patch.object(mod, "list_live_stack_names", side_effect=RuntimeError("boom")):
-            kept = mod._reverify_orphans(object(), "111", self._items(), failed)
+            kept, reprotected = mod._reverify_orphans(object(), "111", self._items(), failed)
         self.assertEqual([k["function"] for k in kept], ["plain"])
-        self.assertEqual(len(failed), 1)
+        self.assertEqual(reprotected, [])
+        self.assertEqual(len(failed), 1)        # real gap -> drives non-zero exit
 
     def test_no_orphans_returns_items_unchanged_without_listing(self):
         failed = []
         items = [{"account": "111", "name": "a", "region": "us-east-1", "function": "plain"}]
         with patch.object(mod, "list_live_stack_names") as lls:
-            kept = mod._reverify_orphans(object(), "111", items, failed)
+            kept, reprotected = mod._reverify_orphans(object(), "111", items, failed)
         self.assertEqual(kept, items)
+        self.assertEqual(reprotected, [])
         lls.assert_not_called()
 
 

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -1,9 +1,10 @@
 import os
 import sys
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.python.common import boto_common
 from src.python.common.boto_common import (
     scan_lambdas_in_region,
     delete_lambda_function,
@@ -36,7 +37,11 @@ class TestScanLambdasInRegion(unittest.TestCase):
         )
         session = _session_with_lambda(client)
 
-        to_delete, skipped, scan_errors = scan_lambdas_in_region(session, "us-east-1", "streamsec")
+        # StreamSec_B's stack is live, so it stays protected (skipped_cfn) rather
+        # than being reclassified as an orphan.
+        with patch.object(boto_common, "list_live_stack_names",
+                           return_value={"LightlyticsStack-x"}):
+            to_delete, skipped, scan_errors = scan_lambdas_in_region(session, "us-east-1", "streamsec")
 
         self.assertEqual([d["function"] for d in to_delete], ["StreamSec_A"])
         self.assertEqual(len(skipped), 1)
@@ -126,6 +131,73 @@ class TestListLiveStackNames(unittest.TestCase):
         session.client.return_value = client
         with self.assertRaises(RuntimeError):
             list_live_stack_names(session, "us-east-1")
+
+
+class TestScanOrphanClassification(unittest.TestCase):
+    def _lambda_session(self, functions_and_tags):
+        # functions_and_tags: list of (name, tags_dict)
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"Functions": [
+            {"FunctionName": n, "FunctionArn": f"arn:{n}"} for n, _ in functions_and_tags]}]
+        client.get_paginator.return_value = paginator
+        tags_by_arn = {f"arn:{n}": t for n, t in functions_and_tags}
+        client.list_tags.side_effect = lambda Resource: {"Tags": tags_by_arn[Resource]}
+        session = MagicMock()
+        session.client.return_value = client
+        return session
+
+    def test_non_cfn_goes_to_delete_without_annotation(self):
+        session = self._lambda_session([("MyCloudWatchColl", {})])
+        with patch.object(boto_common, "list_live_stack_names") as lls:
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch")
+        self.assertEqual(len(to_delete), 1)
+        self.assertNotIn("orphaned_stack", to_delete[0])
+        lls.assert_not_called()            # lazy: no CFN match -> never listed
+
+    def test_cfn_with_live_stack_is_skipped(self):
+        tags = {boto_common.CFN_STACK_NAME_TAG: "live-stack"}
+        session = self._lambda_session([("MyCloudWatchColl", tags)])
+        with patch.object(boto_common, "list_live_stack_names", return_value={"live-stack"}):
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch")
+        self.assertEqual(to_delete, [])
+        self.assertEqual(len(skipped), 1)
+        self.assertEqual(skipped[0]["stack"], "live-stack")
+
+    def test_cfn_with_missing_stack_is_orphan(self):
+        tags = {boto_common.CFN_STACK_NAME_TAG: "gone-stack"}
+        session = self._lambda_session([("MyCloudWatchColl", tags)])
+        with patch.object(boto_common, "list_live_stack_names", return_value={"other"}):
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch")
+        self.assertEqual(skipped, [])
+        self.assertEqual(len(to_delete), 1)
+        self.assertEqual(to_delete[0]["orphaned_stack"], "gone-stack")
+
+    def test_liststacks_error_becomes_scan_gap_not_delete(self):
+        tags = {boto_common.CFN_STACK_NAME_TAG: "gone-stack"}
+        session = self._lambda_session([("MyCloudWatchColl", tags)])
+        with patch.object(boto_common, "list_live_stack_names",
+                          side_effect=RuntimeError("denied")):
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch")
+        self.assertEqual(to_delete, [])
+        self.assertEqual(skipped, [])
+        self.assertEqual(len(errors), 1)
+
+    def test_liststacks_fetched_once_for_multiple_cfn_matches(self):
+        t1 = {boto_common.CFN_STACK_NAME_TAG: "gone-1"}
+        t2 = {boto_common.CFN_STACK_NAME_TAG: "live-2"}
+        session = self._lambda_session([("CloudWatchA", t1), ("CloudWatchB", t2)])
+        with patch.object(boto_common, "list_live_stack_names",
+                          return_value={"live-2"}) as lls:
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch")
+        lls.assert_called_once()           # cached, not per-match
+        self.assertEqual(len(to_delete), 1)   # gone-1 orphan
+        self.assertEqual(len(skipped), 1)     # live-2 protected
 
 
 if __name__ == "__main__":

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -203,6 +203,18 @@ class TestScanOrphanClassification(unittest.TestCase):
         self.assertEqual(len(skipped), 1)
         lls.assert_not_called()            # never even lists this region's stacks
 
+    def test_empty_stack_name_tag_is_protected_not_deleted(self):
+        # stack-name tag present but empty -> can't identify the stack -> protect,
+        # never fall through and delete it as a plain (non-CFN) function.
+        session = self._lambda_session(
+            [("MyCloudWatchColl", {boto_common.CFN_STACK_NAME_TAG: ""})])
+        with patch.object(boto_common, "list_live_stack_names") as lls:
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch")
+        self.assertEqual(to_delete, [])
+        self.assertEqual(len(skipped), 1)
+        lls.assert_not_called()
+
     def test_missing_stack_id_tag_is_protected_not_orphan(self):
         # stack-name present but no stack-id ARN -> region unknown -> protect.
         session = self._lambda_session(
@@ -268,8 +280,17 @@ class TestAccessDeniedDetection(unittest.TestCase):
             err = ClientError({"Error": {"Code": code, "Message": "x"}}, "ListStacks")
             self.assertTrue(boto_common.is_access_denied_error(err))
 
+    def test_true_for_other_403_denial(self):
+        # An SCP/permission-boundary denial with a different code but HTTP 403.
+        err = ClientError(
+            {"Error": {"Code": "AuthorizationError", "Message": "x"},
+             "ResponseMetadata": {"HTTPStatusCode": 403}}, "ListStacks")
+        self.assertTrue(boto_common.is_access_denied_error(err))
+
     def test_false_for_other_errors(self):
-        throttle = ClientError({"Error": {"Code": "Throttling", "Message": "x"}}, "ListStacks")
+        throttle = ClientError(
+            {"Error": {"Code": "Throttling", "Message": "x"},
+             "ResponseMetadata": {"HTTPStatusCode": 400}}, "ListStacks")
         self.assertFalse(boto_common.is_access_denied_error(throttle))
         self.assertFalse(boto_common.is_access_denied_error(RuntimeError("plain")))
 

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -303,6 +303,16 @@ class TestStackIdRegion(unittest.TestCase):
         self.assertIsNone(boto_common.region_from_stack_id(arn))
         self.assertIsNone(boto_common.account_from_stack_id(arn))
 
+    def test_none_for_cfn_arn_that_is_not_a_stack(self):
+        # Correct service + region + account, but the resource is not a stack (e.g.
+        # a changeSet or a bare non-stack resource). Treat as malformed -> protect.
+        for arn in (
+            "arn:aws:cloudformation:us-east-1:123456789012:not-a-stack",
+            "arn:aws:cloudformation:us-east-1:123456789012:changeSet/cs/uuid",
+        ):
+            self.assertIsNone(boto_common.region_from_stack_id(arn))
+            self.assertIsNone(boto_common.account_from_stack_id(arn))
+
 
 class TestAccessDeniedDetection(unittest.TestCase):
     def test_true_for_access_denied_client_error(self):

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -33,15 +33,18 @@ class TestScanLambdasInRegion(unittest.TestCase):
         }]
         client.get_paginator.return_value = paginator
         client.list_tags.side_effect = lambda Resource: (
-            {"Tags": {CFN_STACK_NAME_TAG: "LightlyticsStack-x"}} if Resource == "arn:B"
-            else {"Tags": {}}
+            {"Tags": {CFN_STACK_NAME_TAG: "LightlyticsStack-x",
+                      boto_common.CFN_STACK_ID_TAG:
+                          "arn:aws:cloudformation:us-east-1:123:stack/LightlyticsStack-x/u"}}
+            if Resource == "arn:B" else {"Tags": {}}
         )
         session = _session_with_lambda(client)
 
-        # StreamSec_B's stack is live, so it stays protected (skipped_cfn) rather
-        # than being reclassified as an orphan.
+        # StreamSec_B's stack-id is in this region, so the scan actually lists live
+        # stacks; its stack IS live, so it stays protected (skipped_cfn) via the
+        # stack_name-in-live-set path rather than being reclassified as an orphan.
         with patch.object(boto_common, "list_live_stack_names",
-                           return_value={"LightlyticsStack-x"}):
+                           return_value={"LightlyticsStack-x"}) as lls:
             to_delete, skipped, scan_errors = scan_lambdas_in_region(session, "us-east-1", "streamsec")
 
         self.assertEqual([d["function"] for d in to_delete], ["StreamSec_A"])
@@ -51,6 +54,8 @@ class TestScanLambdasInRegion(unittest.TestCase):
         self.assertEqual(scan_errors, [])
         # list_tags must be called only for name-matched functions (A and B), not C
         self.assertEqual(client.list_tags.call_count, 2)
+        # the live-stack protection path was actually exercised (stack list consulted)
+        lls.assert_called_once()
 
     def test_tag_failure_excludes_function_and_records_error(self):
         client = MagicMock()
@@ -280,13 +285,14 @@ class TestAccessDeniedDetection(unittest.TestCase):
             err = ClientError({"Error": {"Code": code, "Message": "x"}}, "ListStacks")
             self.assertTrue(boto_common.is_access_denied_error(err))
 
-    def test_true_for_authorization_denial_codes(self):
-        # SCP / permission-boundary denials surface as these codes.
+    def test_false_for_non_cfn_denial_codes(self):
+        # CloudFormation ListStacks emits AccessDenied; EC2-style codes like these
+        # are not emitted by CFN, so they fall through to the safe scan-gap path.
         for code in ("AuthorizationError", "UnauthorizedOperation"):
             err = ClientError(
                 {"Error": {"Code": code, "Message": "x"},
                  "ResponseMetadata": {"HTTPStatusCode": 403}}, "ListStacks")
-            self.assertTrue(boto_common.is_access_denied_error(err))
+            self.assertFalse(boto_common.is_access_denied_error(err))
 
     def test_false_for_expired_token_even_though_403(self):
         # Transient credential expiry is HTTP 403 but must NOT be treated as a

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -280,12 +280,22 @@ class TestAccessDeniedDetection(unittest.TestCase):
             err = ClientError({"Error": {"Code": code, "Message": "x"}}, "ListStacks")
             self.assertTrue(boto_common.is_access_denied_error(err))
 
-    def test_true_for_other_403_denial(self):
-        # An SCP/permission-boundary denial with a different code but HTTP 403.
-        err = ClientError(
-            {"Error": {"Code": "AuthorizationError", "Message": "x"},
-             "ResponseMetadata": {"HTTPStatusCode": 403}}, "ListStacks")
-        self.assertTrue(boto_common.is_access_denied_error(err))
+    def test_true_for_authorization_denial_codes(self):
+        # SCP / permission-boundary denials surface as these codes.
+        for code in ("AuthorizationError", "UnauthorizedOperation"):
+            err = ClientError(
+                {"Error": {"Code": code, "Message": "x"},
+                 "ResponseMetadata": {"HTTPStatusCode": 403}}, "ListStacks")
+            self.assertTrue(boto_common.is_access_denied_error(err))
+
+    def test_false_for_expired_token_even_though_403(self):
+        # Transient credential expiry is HTTP 403 but must NOT be treated as a
+        # permission denial — it should fall through to the scan-gap path.
+        for code in ("ExpiredToken", "ExpiredTokenException", "RequestExpired"):
+            err = ClientError(
+                {"Error": {"Code": code, "Message": "x"},
+                 "ResponseMetadata": {"HTTPStatusCode": 403}}, "ListStacks")
+            self.assertFalse(boto_common.is_access_denied_error(err))
 
     def test_false_for_other_errors(self):
         throttle = ClientError(

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -7,6 +7,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from src.python.common.boto_common import (
     scan_lambdas_in_region,
     delete_lambda_function,
+    list_live_stack_names,
     CFN_STACK_NAME_TAG,
 )
 
@@ -88,6 +89,43 @@ class TestDeleteLambdaFunction(unittest.TestCase):
         client.delete_function.side_effect = not_found()
         session = _session_with_lambda(client)
         self.assertEqual(delete_lambda_function(session, "us-east-1", "fn"), "already gone")
+
+
+class TestListLiveStackNames(unittest.TestCase):
+    def _session_with_pages(self, pages):
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = pages
+        client.get_paginator.return_value = paginator
+        session = MagicMock()
+        session.client.return_value = client
+        return session, client
+
+    def test_returns_live_names_and_filters_delete_complete(self):
+        pages = [{"StackSummaries": [
+            {"StackName": "live-a", "StackStatus": "CREATE_COMPLETE"},
+            {"StackName": "gone-b", "StackStatus": "DELETE_COMPLETE"},
+            {"StackName": "live-c", "StackStatus": "UPDATE_COMPLETE"},
+        ]}]
+        session, _ = self._session_with_pages(pages)
+        result = list_live_stack_names(session, "us-east-1")
+        self.assertEqual(result, {"live-a", "live-c"})
+
+    def test_paginates_across_pages(self):
+        pages = [
+            {"StackSummaries": [{"StackName": "a", "StackStatus": "CREATE_COMPLETE"}]},
+            {"StackSummaries": [{"StackName": "b", "StackStatus": "CREATE_COMPLETE"}]},
+        ]
+        session, _ = self._session_with_pages(pages)
+        self.assertEqual(list_live_stack_names(session, "us-east-1"), {"a", "b"})
+
+    def test_api_error_propagates(self):
+        session = MagicMock()
+        client = MagicMock()
+        client.get_paginator.side_effect = RuntimeError("access denied")
+        session.client.return_value = client
+        with self.assertRaises(RuntimeError):
+            list_live_stack_names(session, "us-east-1")
 
 
 if __name__ == "__main__":

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -45,7 +45,8 @@ class TestScanLambdasInRegion(unittest.TestCase):
         # stack_name-in-live-set path rather than being reclassified as an orphan.
         with patch.object(boto_common, "list_live_stack_names",
                            return_value={"LightlyticsStack-x"}) as lls:
-            to_delete, skipped, scan_errors = scan_lambdas_in_region(session, "us-east-1", "streamsec")
+            to_delete, skipped, scan_errors = scan_lambdas_in_region(
+                session, "us-east-1", "streamsec", "123")
 
         self.assertEqual([d["function"] for d in to_delete], ["StreamSec_A"])
         self.assertEqual(len(skipped), 1)
@@ -75,7 +76,8 @@ class TestScanLambdasInRegion(unittest.TestCase):
         client.list_tags.side_effect = _tags
         session = _session_with_lambda(client)
 
-        to_delete, skipped, scan_errors = scan_lambdas_in_region(session, "us-east-1", "streamsec")
+        to_delete, skipped, scan_errors = scan_lambdas_in_region(
+            session, "us-east-1", "streamsec", "123456789012")
 
         # A tag failure must NOT abort the region: the good function is still found,
         # the bad one is left out of to_delete and recorded as a scan error.
@@ -172,7 +174,7 @@ class TestScanOrphanClassification(unittest.TestCase):
         session = self._lambda_session([("MyCloudWatchColl", {})])
         with patch.object(boto_common, "list_live_stack_names") as lls:
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
-                session, "us-east-1", "cloudwatch")
+                session, "us-east-1", "cloudwatch", "123456789012")
         self.assertEqual(len(to_delete), 1)
         self.assertNotIn("orphaned_stack", to_delete[0])
         lls.assert_not_called()            # lazy: no CFN match -> never listed
@@ -181,7 +183,7 @@ class TestScanOrphanClassification(unittest.TestCase):
         session = self._lambda_session([("MyCloudWatchColl", self._cfn_tags("live-stack"))])
         with patch.object(boto_common, "list_live_stack_names", return_value={"live-stack"}):
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
-                session, "us-east-1", "cloudwatch")
+                session, "us-east-1", "cloudwatch", "123456789012")
         self.assertEqual(to_delete, [])
         self.assertEqual(len(skipped), 1)
         self.assertEqual(skipped[0]["stack"], "live-stack")
@@ -190,7 +192,7 @@ class TestScanOrphanClassification(unittest.TestCase):
         session = self._lambda_session([("MyCloudWatchColl", self._cfn_tags("gone-stack"))])
         with patch.object(boto_common, "list_live_stack_names", return_value={"other"}):
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
-                session, "us-east-1", "cloudwatch")
+                session, "us-east-1", "cloudwatch", "123456789012")
         self.assertEqual(skipped, [])
         self.assertEqual(len(to_delete), 1)
         self.assertEqual(to_delete[0]["orphaned_stack"], "gone-stack")
@@ -203,7 +205,7 @@ class TestScanOrphanClassification(unittest.TestCase):
         with patch.object(boto_common, "list_live_stack_names",
                           return_value=set()) as lls:
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
-                session, "us-east-1", "cloudwatch")
+                session, "us-east-1", "cloudwatch", "123456789012")
         self.assertEqual(to_delete, [])
         self.assertEqual(len(skipped), 1)
         lls.assert_not_called()            # never even lists this region's stacks
@@ -215,10 +217,26 @@ class TestScanOrphanClassification(unittest.TestCase):
             [("MyCloudWatchColl", {boto_common.CFN_STACK_NAME_TAG: ""})])
         with patch.object(boto_common, "list_live_stack_names") as lls:
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
-                session, "us-east-1", "cloudwatch")
+                session, "us-east-1", "cloudwatch", "123456789012")
         self.assertEqual(to_delete, [])
         self.assertEqual(len(skipped), 1)
         lls.assert_not_called()
+
+    def test_stack_in_another_account_is_protected_not_orphan(self):
+        # Same region but the stack-id points at a DIFFERENT account. Listing THIS
+        # account's stacks can't confirm that stack is gone, so it must be protected
+        # (never deleted while it may be live in the other account).
+        tags = {boto_common.CFN_STACK_NAME_TAG: "foreign",
+                boto_common.CFN_STACK_ID_TAG:
+                    "arn:aws:cloudformation:us-east-1:999999999999:stack/foreign/u"}
+        session = self._lambda_session([("MyCloudWatchColl", tags)])
+        with patch.object(boto_common, "list_live_stack_names",
+                          return_value=set()) as lls:
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch", "123456789012")
+        self.assertEqual(to_delete, [])
+        self.assertEqual(len(skipped), 1)
+        lls.assert_not_called()            # never lists the wrong account's stacks
 
     def test_missing_stack_id_tag_is_protected_not_orphan(self):
         # stack-name present but no stack-id ARN -> region unknown -> protect.
@@ -227,7 +245,7 @@ class TestScanOrphanClassification(unittest.TestCase):
         with patch.object(boto_common, "list_live_stack_names",
                           return_value=set()) as lls:
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
-                session, "us-east-1", "cloudwatch")
+                session, "us-east-1", "cloudwatch", "123456789012")
         self.assertEqual(to_delete, [])
         self.assertEqual(len(skipped), 1)
         lls.assert_not_called()
@@ -240,7 +258,7 @@ class TestScanOrphanClassification(unittest.TestCase):
         session = self._lambda_session([("MyCloudWatchColl", self._cfn_tags("some-stack"))])
         with patch.object(boto_common, "list_live_stack_names", side_effect=denied):
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
-                session, "us-east-1", "cloudwatch")
+                session, "us-east-1", "cloudwatch", "123456789012")
         self.assertEqual(to_delete, [])
         self.assertEqual(errors, [])
         self.assertEqual(len(skipped), 1)
@@ -250,7 +268,7 @@ class TestScanOrphanClassification(unittest.TestCase):
         with patch.object(boto_common, "list_live_stack_names",
                           side_effect=RuntimeError("boom")):
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
-                session, "us-east-1", "cloudwatch")
+                session, "us-east-1", "cloudwatch", "123456789012")
         self.assertEqual(to_delete, [])
         self.assertEqual(skipped, [])
         self.assertEqual(len(errors), 1)
@@ -262,21 +280,28 @@ class TestScanOrphanClassification(unittest.TestCase):
         with patch.object(boto_common, "list_live_stack_names",
                           return_value={"live-2"}) as lls:
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
-                session, "us-east-1", "cloudwatch")
+                session, "us-east-1", "cloudwatch", "123456789012")
         lls.assert_called_once()           # cached, not per-match
         self.assertEqual(len(to_delete), 1)   # gone-1 orphan
         self.assertEqual(len(skipped), 1)     # live-2 protected
 
 
 class TestStackIdRegion(unittest.TestCase):
-    def test_parses_region_from_arn(self):
+    def test_parses_region_and_account_from_arn(self):
         arn = "arn:aws:cloudformation:eu-west-1:123456789012:stack/my-stack/abc"
         self.assertEqual(boto_common.region_from_stack_id(arn), "eu-west-1")
+        self.assertEqual(boto_common.account_from_stack_id(arn), "123456789012")
 
     def test_none_for_missing_or_malformed(self):
-        self.assertIsNone(boto_common.region_from_stack_id(None))
-        self.assertIsNone(boto_common.region_from_stack_id(""))
-        self.assertIsNone(boto_common.region_from_stack_id("not-an-arn"))
+        for bad in (None, "", "not-an-arn", "arn:aws:cloudformation:us-east-1"):
+            self.assertIsNone(boto_common.region_from_stack_id(bad))
+            self.assertIsNone(boto_common.account_from_stack_id(bad))
+
+    def test_none_for_non_cloudformation_arn(self):
+        # A stray non-CFN ARN must not be read as a stack reference.
+        arn = "arn:aws:lambda:us-east-1:123456789012:function:foo"
+        self.assertIsNone(boto_common.region_from_stack_id(arn))
+        self.assertIsNone(boto_common.account_from_stack_id(arn))
 
 
 class TestAccessDeniedDetection(unittest.TestCase):

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -115,6 +115,11 @@ class TestListLiveStackNames(unittest.TestCase):
         session, _ = self._session_with_pages(pages)
         result = list_live_stack_names(session, "us-east-1")
         self.assertEqual(result, {"live-a", "live-c"})
+        # Built for the cloudformation service in the right region with the
+        # shared retry/timeout config — guards against a wrong service string.
+        session.client.assert_called_once_with(
+            "cloudformation", region_name="us-east-1",
+            config=boto_common.LAMBDA_CLIENT_CONFIG)
 
     def test_paginates_across_pages(self):
         pages = [

--- a/tests/test_lambda_delete_boto.py
+++ b/tests/test_lambda_delete_boto.py
@@ -2,6 +2,7 @@ import os
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
+from botocore.exceptions import ClientError
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from src.python.common import boto_common
@@ -152,6 +153,16 @@ class TestScanOrphanClassification(unittest.TestCase):
         session.client.return_value = client
         return session
 
+    @staticmethod
+    def _cfn_tags(stack_name, region="us-east-1"):
+        # A CFN-managed lambda carries both the stack-name and a stack-id ARN; the
+        # scan uses the ARN's region to verify the stack in its OWNING region.
+        return {
+            boto_common.CFN_STACK_NAME_TAG: stack_name,
+            boto_common.CFN_STACK_ID_TAG:
+                f"arn:aws:cloudformation:{region}:123456789012:stack/{stack_name}/uuid",
+        }
+
     def test_non_cfn_goes_to_delete_without_annotation(self):
         session = self._lambda_session([("MyCloudWatchColl", {})])
         with patch.object(boto_common, "list_live_stack_names") as lls:
@@ -162,8 +173,7 @@ class TestScanOrphanClassification(unittest.TestCase):
         lls.assert_not_called()            # lazy: no CFN match -> never listed
 
     def test_cfn_with_live_stack_is_skipped(self):
-        tags = {boto_common.CFN_STACK_NAME_TAG: "live-stack"}
-        session = self._lambda_session([("MyCloudWatchColl", tags)])
+        session = self._lambda_session([("MyCloudWatchColl", self._cfn_tags("live-stack"))])
         with patch.object(boto_common, "list_live_stack_names", return_value={"live-stack"}):
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
                 session, "us-east-1", "cloudwatch")
@@ -172,8 +182,7 @@ class TestScanOrphanClassification(unittest.TestCase):
         self.assertEqual(skipped[0]["stack"], "live-stack")
 
     def test_cfn_with_missing_stack_is_orphan(self):
-        tags = {boto_common.CFN_STACK_NAME_TAG: "gone-stack"}
-        session = self._lambda_session([("MyCloudWatchColl", tags)])
+        session = self._lambda_session([("MyCloudWatchColl", self._cfn_tags("gone-stack"))])
         with patch.object(boto_common, "list_live_stack_names", return_value={"other"}):
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
                 session, "us-east-1", "cloudwatch")
@@ -181,11 +190,48 @@ class TestScanOrphanClassification(unittest.TestCase):
         self.assertEqual(len(to_delete), 1)
         self.assertEqual(to_delete[0]["orphaned_stack"], "gone-stack")
 
-    def test_liststacks_error_becomes_scan_gap_not_delete(self):
-        tags = {boto_common.CFN_STACK_NAME_TAG: "gone-stack"}
-        session = self._lambda_session([("MyCloudWatchColl", tags)])
+    def test_stack_in_another_region_is_protected_not_orphan(self):
+        # Stack lives in eu-west-1; scanning us-east-1 can't confirm it is gone,
+        # so it must be protected (skipped), never deleted.
+        session = self._lambda_session(
+            [("MyCloudWatchColl", self._cfn_tags("elsewhere", region="eu-west-1"))])
         with patch.object(boto_common, "list_live_stack_names",
-                          side_effect=RuntimeError("denied")):
+                          return_value=set()) as lls:
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch")
+        self.assertEqual(to_delete, [])
+        self.assertEqual(len(skipped), 1)
+        lls.assert_not_called()            # never even lists this region's stacks
+
+    def test_missing_stack_id_tag_is_protected_not_orphan(self):
+        # stack-name present but no stack-id ARN -> region unknown -> protect.
+        session = self._lambda_session(
+            [("MyCloudWatchColl", {boto_common.CFN_STACK_NAME_TAG: "no-id"})])
+        with patch.object(boto_common, "list_live_stack_names",
+                          return_value=set()) as lls:
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch")
+        self.assertEqual(to_delete, [])
+        self.assertEqual(len(skipped), 1)
+        lls.assert_not_called()
+
+    def test_access_denied_falls_back_to_skip_not_gap(self):
+        # No cloudformation:ListStacks permission -> behave as before orphan
+        # detection: skip the CFN-tagged function, no scan gap.
+        denied = ClientError({"Error": {"Code": "AccessDenied", "Message": "no"}},
+                             "ListStacks")
+        session = self._lambda_session([("MyCloudWatchColl", self._cfn_tags("some-stack"))])
+        with patch.object(boto_common, "list_live_stack_names", side_effect=denied):
+            to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
+                session, "us-east-1", "cloudwatch")
+        self.assertEqual(to_delete, [])
+        self.assertEqual(errors, [])
+        self.assertEqual(len(skipped), 1)
+
+    def test_liststacks_error_becomes_scan_gap_not_delete(self):
+        session = self._lambda_session([("MyCloudWatchColl", self._cfn_tags("gone-stack"))])
+        with patch.object(boto_common, "list_live_stack_names",
+                          side_effect=RuntimeError("boom")):
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
                 session, "us-east-1", "cloudwatch")
         self.assertEqual(to_delete, [])
@@ -193,9 +239,9 @@ class TestScanOrphanClassification(unittest.TestCase):
         self.assertEqual(len(errors), 1)
 
     def test_liststacks_fetched_once_for_multiple_cfn_matches(self):
-        t1 = {boto_common.CFN_STACK_NAME_TAG: "gone-1"}
-        t2 = {boto_common.CFN_STACK_NAME_TAG: "live-2"}
-        session = self._lambda_session([("CloudWatchA", t1), ("CloudWatchB", t2)])
+        session = self._lambda_session([
+            ("CloudWatchA", self._cfn_tags("gone-1")),
+            ("CloudWatchB", self._cfn_tags("live-2"))])
         with patch.object(boto_common, "list_live_stack_names",
                           return_value={"live-2"}) as lls:
             to_delete, skipped, errors = boto_common.scan_lambdas_in_region(
@@ -203,6 +249,29 @@ class TestScanOrphanClassification(unittest.TestCase):
         lls.assert_called_once()           # cached, not per-match
         self.assertEqual(len(to_delete), 1)   # gone-1 orphan
         self.assertEqual(len(skipped), 1)     # live-2 protected
+
+
+class TestStackIdRegion(unittest.TestCase):
+    def test_parses_region_from_arn(self):
+        arn = "arn:aws:cloudformation:eu-west-1:123456789012:stack/my-stack/abc"
+        self.assertEqual(boto_common.region_from_stack_id(arn), "eu-west-1")
+
+    def test_none_for_missing_or_malformed(self):
+        self.assertIsNone(boto_common.region_from_stack_id(None))
+        self.assertIsNone(boto_common.region_from_stack_id(""))
+        self.assertIsNone(boto_common.region_from_stack_id("not-an-arn"))
+
+
+class TestAccessDeniedDetection(unittest.TestCase):
+    def test_true_for_access_denied_client_error(self):
+        for code in ("AccessDenied", "AccessDeniedException"):
+            err = ClientError({"Error": {"Code": code, "Message": "x"}}, "ListStacks")
+            self.assertTrue(boto_common.is_access_denied_error(err))
+
+    def test_false_for_other_errors(self):
+        throttle = ClientError({"Error": {"Code": "Throttling", "Message": "x"}}, "ListStacks")
+        self.assertFalse(boto_common.is_access_denied_error(throttle))
+        self.assertFalse(boto_common.is_access_denied_error(RuntimeError("plain")))
 
 
 if __name__ == "__main__":

--- a/tests/test_lambda_delete_report.py
+++ b/tests/test_lambda_delete_report.py
@@ -64,7 +64,9 @@ class TestOrphanReporting(unittest.TestCase):
         ]
         lines = format_plan_lines(results)
         self.assertEqual(lines[0], "111 | us-east-1 | plain")
-        self.assertEqual(lines[1], "222 | us-east-1 | orph (orphaned; stack dead-stack gone)")
+        # Orphan context is a 4th pipe field so field[2] stays the bare function name.
+        self.assertEqual(lines[1], "222 | us-east-1 | orph | orphaned (stack dead-stack gone)")
+        self.assertEqual(lines[1].split(" | ")[2], "orph")
 
     def test_summary_reports_orphan_subcount(self):
         import io, contextlib

--- a/tests/test_lambda_delete_report.py
+++ b/tests/test_lambda_delete_report.py
@@ -8,6 +8,7 @@ from src.python.common.boto_common import (
     write_plan_file,
     print_lambda_plan,
     print_lambda_summary,
+    format_plan_lines,
 )
 
 
@@ -52,6 +53,32 @@ class TestPrintSummaryExitCount(unittest.TestCase):
 class TestPrintPlanEmptySafe(unittest.TestCase):
     def test_no_crash_on_empty(self):
         print_lambda_plan([], [])
+
+
+class TestOrphanReporting(unittest.TestCase):
+    def test_format_plan_lines_annotates_orphans_only(self):
+        results = [
+            {"account": "111", "region": "us-east-1", "function": "plain"},
+            {"account": "222", "region": "us-east-1", "function": "orph",
+             "orphaned_stack": "dead-stack"},
+        ]
+        lines = format_plan_lines(results)
+        self.assertEqual(lines[0], "111 | us-east-1 | plain")
+        self.assertEqual(lines[1], "222 | us-east-1 | orph (orphaned; stack dead-stack gone)")
+
+    def test_summary_reports_orphan_subcount(self):
+        import io, contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = print_lambda_summary(
+                deleted=[{"account": "1", "region": "us-east-1", "function": "a",
+                          "orphaned_stack": "gone"},
+                         {"account": "1", "region": "us-east-1", "function": "b"}],
+                already_gone=[], failed=[], skipped_cfn=[], assume_role_failures=[])
+        out = buf.getvalue()
+        self.assertIn("2 deleted", out)
+        self.assertIn("1 orphaned CFN", out)
+        self.assertEqual(code, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Extends lambda-only mode (`--lambda_name_contains`) so it also deletes Lambda functions that carry stale CloudFormation tags but whose stack no longer exists ("orphans"), while continuing to protect functions owned by a live stack.

## Why

A Lambda retained after its CloudFormation stack is deleted keeps the `aws:cloudformation:*` tags. The previous tag-only check treated those as CloudFormation-managed and skipped them, so orphaned collectors could never be cleaned up.

## Behavior

- For each name-matched, CFN-tagged function, the scan verifies the stack still exists, in the stack's own region (derived from the `aws:cloudformation:stack-id` tag):
  - stack live → **skip** (protected)
  - stack gone → **orphan → delete** (annotated in the plan/summary)
  - can't confirm → reported as a **scan gap**, never deleted
- The delete phase re-verifies each orphan's stack is still gone immediately before deleting (guards a scan→delete race); a stack that reappeared is protected, not deleted.
- If the role lacks `cloudformation:ListStacks` (AccessDenied), it falls back to the prior behavior — skip all CFN-tagged functions and exit clean.
- CloudFormation stack-deletion mode is unchanged.

## New requirement

The role now needs `cloudformation:ListStacks` in each target account/region (the admin `OrganizationAccountAccessRole` already has it).

## Testing

- Unit tests covering the new classification, region gating, access-denied fallback, delete-time re-verify, and reporting.
- Validated end-to-end against a live account: an orphaned function (stack deleted, function retained) is deleted while a live-stack function is left untouched.
