### PR TITLE
Fix EKS audit-log region detection; add --eks_audit_logs_auto_detect flag

### DIFF
--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -28,7 +28,6 @@ def lambda_handler(event, context):
     eks_audit_logs_regions = os.environ.get('EKS_AUDIT_LOGS_REGIONS', None)
     if eks_audit_logs_regions:
         eks_audit_logs_regions = eks_audit_logs_regions.split(",")
-    eks_audit_logs_auto_detect = os.environ.get('EKS_AUDIT_LOGS_AUTO_DETECT', 'false').lower() == 'true'
 
     # Setting up variables
     random_int = random.randint(1000000, 9999999)
@@ -86,7 +85,7 @@ def lambda_handler(event, context):
                     sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate,
                     control_role, org_account_id, parallel,
                     response, response_region, response_exclude_runbooks, environment, domain,
-                    eks_audit_logs, eks_audit_logs_regions, eks_audit_logs_auto_detect
+                    eks_audit_logs, eks_audit_logs_regions
                 ): sub_account for sub_account in sub_accounts
             }
             for future in concurrent.futures.as_completed(future_to_account):
@@ -102,7 +101,7 @@ def lambda_handler(event, context):
                     sub_account, sts_client, graph_client, regions, random_int,
                     custom_tags, regions_to_integrate, control_role, org_account_id,
                     parallel, response, response_region, response_exclude_runbooks, environment, domain,
-                    eks_audit_logs, eks_audit_logs_regions, eks_audit_logs_auto_detect
+                    eks_audit_logs, eks_audit_logs_regions
                 )
             except Exception as e:
                 failures.append((sub_account[0], str(e)))
@@ -118,7 +117,7 @@ def lambda_handler(event, context):
 def integrate_sub_account(
         sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate, control_role,
         org_account_id, parallel=False, response=False, response_region="us-east-1", response_exclude_runbooks="", environment=None, domain=None,
-        eks_audit_logs=False, eks_audit_logs_regions=None, eks_audit_logs_auto_detect=False):
+        eks_audit_logs=False, eks_audit_logs_regions=None):
     print(color(f"Account: {sub_account[0]} | Starting integration", color="blue"))
     try:
         if sub_account[0] == org_account_id:
@@ -168,34 +167,16 @@ def integrate_sub_account(
                     deploy_response_stack(
                         f"https://{environment}.{domain}/graphql", sub_account_information, sub_account_session, sub_account,
                         response_region, random_int, custom_tags, response_exclude_runbooks, wait=False)
+                # Deploying EKS audit logs if enabled
+                if eks_audit_logs:
+                    deploy_eks_audit_logs_stacks(
+                        f"https://{environment}.{domain}/graphql", sub_account_information, sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
                 print(color(f"Account: {sub_account[0]} | Checking if regions are updated", "blue"))
                 current_regions = sub_account_information["cloud_regions"]
                 if regions_to_integrate:
                     potential_regions = regions_to_integrate
                 else:
                     potential_regions = get_active_regions(sub_account_session, regions)
-
-                # Deploying EKS audit logs if enabled. eks_audit_logs_auto_detect
-                # forces auto-detection (regions=None) regardless of
-                # eks_audit_logs_regions - it's the explicit "just detect and
-                # deploy where EKS clusters are found" mode, so it must scan
-                # potential_regions (real EC2-instance-detected active
-                # regions, just computed above), not
-                # sub_account_information["cloud_regions"] (the account's
-                # currently-registered region list in StreamSecurity, which
-                # may be stale if new regions became active since last
-                # onboarding). Plain --eks_audit_logs keeps its existing
-                # behavior (scanning cloud_regions) unchanged.
-                if eks_audit_logs or eks_audit_logs_auto_detect:
-                    regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
-                    # list(potential_regions): a copy, not a reference - it's
-                    # extended in place further down in this same function.
-                    eks_account_information = (
-                        {**sub_account_information, "cloud_regions": list(potential_regions)}
-                        if eks_audit_logs_auto_detect else sub_account_information)
-                    deploy_eks_audit_logs_stacks(
-                        f"https://{environment}.{domain}/graphql", eks_account_information, sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
-
                 if sorted(current_regions) != sorted(potential_regions):
                     potential_regions.extend(current_regions)
                     potential_regions = list(set(potential_regions))
@@ -266,21 +247,10 @@ def integrate_sub_account(
                 f"https://{environment}.{domain}/graphql", account_information, sub_account_session, sub_account,
                 response_region, random_int, custom_tags, response_exclude_runbooks, wait=False)
 
-        # Deploying EKS audit logs if enabled. account_information["cloud_regions"]
-        # is still the backend's stale value from account creation (at most the
-        # session's own region) - deploy_eks_audit_logs_stacks' own auto-detect
-        # fallback would scan only that if given account_information as-is,
-        # silently missing EKS clusters in any other active region.
-        # active_regions (just computed above via real EC2 instance detection
-        # across all candidate regions) is what should be scanned instead.
-        if eks_audit_logs or eks_audit_logs_auto_detect:
-            # eks_audit_logs_auto_detect forces auto-detection (regions=None)
-            # regardless of eks_audit_logs_regions - it's the explicit "just
-            # detect and deploy where EKS clusters are found" mode.
-            regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
+        # Deploying EKS audit logs if enabled
+        if eks_audit_logs:
             deploy_eks_audit_logs_stacks(
-                f"https://{environment}.{domain}/graphql", {**account_information, "cloud_regions": active_regions},
-                sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
+                f"https://{environment}.{domain}/graphql", account_information, sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
 
         if not update_regions(graph_client, sub_account, active_regions, not parallel):
             err_msg = f"Account: {sub_account[0]} | Something went wrong with regions update"

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -247,10 +247,17 @@ def integrate_sub_account(
                 f"https://{environment}.{domain}/graphql", account_information, sub_account_session, sub_account,
                 response_region, random_int, custom_tags, response_exclude_runbooks, wait=False)
 
-        # Deploying EKS audit logs if enabled
+        # Deploying EKS audit logs if enabled. account_information["cloud_regions"]
+        # is still the backend's stale value from account creation (at most the
+        # session's own region) - deploy_eks_audit_logs_stacks' own auto-detect
+        # fallback would scan only that if given account_information as-is,
+        # silently missing EKS clusters in any other active region.
+        # active_regions (just computed above via real EC2 instance detection
+        # across all candidate regions) is what should be scanned instead.
         if eks_audit_logs:
             deploy_eks_audit_logs_stacks(
-                f"https://{environment}.{domain}/graphql", account_information, sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
+                f"https://{environment}.{domain}/graphql", {**account_information, "cloud_regions": active_regions},
+                sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
 
         if not update_regions(graph_client, sub_account, active_regions, not parallel):
             err_msg = f"Account: {sub_account[0]} | Something went wrong with regions update"

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -28,6 +28,7 @@ def lambda_handler(event, context):
     eks_audit_logs_regions = os.environ.get('EKS_AUDIT_LOGS_REGIONS', None)
     if eks_audit_logs_regions:
         eks_audit_logs_regions = eks_audit_logs_regions.split(",")
+    eks_audit_logs_auto_detect = os.environ.get('EKS_AUDIT_LOGS_AUTO_DETECT', 'false').lower() == 'true'
 
     # Setting up variables
     random_int = random.randint(1000000, 9999999)
@@ -85,7 +86,7 @@ def lambda_handler(event, context):
                     sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate,
                     control_role, org_account_id, parallel,
                     response, response_region, response_exclude_runbooks, environment, domain,
-                    eks_audit_logs, eks_audit_logs_regions
+                    eks_audit_logs, eks_audit_logs_regions, eks_audit_logs_auto_detect
                 ): sub_account for sub_account in sub_accounts
             }
             for future in concurrent.futures.as_completed(future_to_account):
@@ -101,7 +102,7 @@ def lambda_handler(event, context):
                     sub_account, sts_client, graph_client, regions, random_int,
                     custom_tags, regions_to_integrate, control_role, org_account_id,
                     parallel, response, response_region, response_exclude_runbooks, environment, domain,
-                    eks_audit_logs, eks_audit_logs_regions
+                    eks_audit_logs, eks_audit_logs_regions, eks_audit_logs_auto_detect
                 )
             except Exception as e:
                 failures.append((sub_account[0], str(e)))
@@ -117,7 +118,7 @@ def lambda_handler(event, context):
 def integrate_sub_account(
         sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate, control_role,
         org_account_id, parallel=False, response=False, response_region="us-east-1", response_exclude_runbooks="", environment=None, domain=None,
-        eks_audit_logs=False, eks_audit_logs_regions=None):
+        eks_audit_logs=False, eks_audit_logs_regions=None, eks_audit_logs_auto_detect=False):
     print(color(f"Account: {sub_account[0]} | Starting integration", color="blue"))
     try:
         if sub_account[0] == org_account_id:
@@ -167,10 +168,14 @@ def integrate_sub_account(
                     deploy_response_stack(
                         f"https://{environment}.{domain}/graphql", sub_account_information, sub_account_session, sub_account,
                         response_region, random_int, custom_tags, response_exclude_runbooks, wait=False)
-                # Deploying EKS audit logs if enabled
-                if eks_audit_logs:
+                # Deploying EKS audit logs if enabled. eks_audit_logs_auto_detect
+                # forces auto-detection (regions=None) regardless of
+                # eks_audit_logs_regions - it's the explicit "just detect and
+                # deploy where EKS clusters are found" mode.
+                if eks_audit_logs or eks_audit_logs_auto_detect:
+                    regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
                     deploy_eks_audit_logs_stacks(
-                        f"https://{environment}.{domain}/graphql", sub_account_information, sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
+                        f"https://{environment}.{domain}/graphql", sub_account_information, sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
                 print(color(f"Account: {sub_account[0]} | Checking if regions are updated", "blue"))
                 current_regions = sub_account_information["cloud_regions"]
                 if regions_to_integrate:
@@ -254,10 +259,14 @@ def integrate_sub_account(
         # silently missing EKS clusters in any other active region.
         # active_regions (just computed above via real EC2 instance detection
         # across all candidate regions) is what should be scanned instead.
-        if eks_audit_logs:
+        if eks_audit_logs or eks_audit_logs_auto_detect:
+            # eks_audit_logs_auto_detect forces auto-detection (regions=None)
+            # regardless of eks_audit_logs_regions - it's the explicit "just
+            # detect and deploy where EKS clusters are found" mode.
+            regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
             deploy_eks_audit_logs_stacks(
                 f"https://{environment}.{domain}/graphql", {**account_information, "cloud_regions": active_regions},
-                sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
+                sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
 
         if not update_regions(graph_client, sub_account, active_regions, not parallel):
             err_msg = f"Account: {sub_account[0]} | Something went wrong with regions update"

--- a/lambda/organization_integration/app.py
+++ b/lambda/organization_integration/app.py
@@ -168,20 +168,34 @@ def integrate_sub_account(
                     deploy_response_stack(
                         f"https://{environment}.{domain}/graphql", sub_account_information, sub_account_session, sub_account,
                         response_region, random_int, custom_tags, response_exclude_runbooks, wait=False)
-                # Deploying EKS audit logs if enabled. eks_audit_logs_auto_detect
-                # forces auto-detection (regions=None) regardless of
-                # eks_audit_logs_regions - it's the explicit "just detect and
-                # deploy where EKS clusters are found" mode.
-                if eks_audit_logs or eks_audit_logs_auto_detect:
-                    regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
-                    deploy_eks_audit_logs_stacks(
-                        f"https://{environment}.{domain}/graphql", sub_account_information, sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
                 print(color(f"Account: {sub_account[0]} | Checking if regions are updated", "blue"))
                 current_regions = sub_account_information["cloud_regions"]
                 if regions_to_integrate:
                     potential_regions = regions_to_integrate
                 else:
                     potential_regions = get_active_regions(sub_account_session, regions)
+
+                # Deploying EKS audit logs if enabled. eks_audit_logs_auto_detect
+                # forces auto-detection (regions=None) regardless of
+                # eks_audit_logs_regions - it's the explicit "just detect and
+                # deploy where EKS clusters are found" mode, so it must scan
+                # potential_regions (real EC2-instance-detected active
+                # regions, just computed above), not
+                # sub_account_information["cloud_regions"] (the account's
+                # currently-registered region list in StreamSecurity, which
+                # may be stale if new regions became active since last
+                # onboarding). Plain --eks_audit_logs keeps its existing
+                # behavior (scanning cloud_regions) unchanged.
+                if eks_audit_logs or eks_audit_logs_auto_detect:
+                    regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
+                    # list(potential_regions): a copy, not a reference - it's
+                    # extended in place further down in this same function.
+                    eks_account_information = (
+                        {**sub_account_information, "cloud_regions": list(potential_regions)}
+                        if eks_audit_logs_auto_detect else sub_account_information)
+                    deploy_eks_audit_logs_stacks(
+                        f"https://{environment}.{domain}/graphql", eks_account_information, sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
+
                 if sorted(current_regions) != sorted(potential_regions):
                     potential_regions.extend(current_regions)
                     potential_regions = list(set(potential_regions))

--- a/src/python/utilities/organization_integration.py
+++ b/src/python/utilities/organization_integration.py
@@ -394,11 +394,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--eks_audit_logs_regions", help="Regions for EKS audit logs, separated by comma", required=False)
     parser.add_argument(
-        "--eks_audit_logs_auto_detect",
-        help="Auto-detect active EKS regions per account (based on real EC2-instance-detected active "
-             "regions) and deploy the EKS audit-log stack only where clusters are actually found. "
-             "Independent of --eks_audit_logs/--eks_audit_logs_regions; overrides --eks_audit_logs_regions "
-             "if both are passed.",
+        "--eks_audit_logs_auto_detect", help="Auto-detect EKS clusters and deploy audit logs only where found",
         action="store_true", required=False)
     args = parser.parse_args()
     main(args.environment_url, args.environment_user_name, args.environment_password,

--- a/src/python/utilities/organization_integration.py
+++ b/src/python/utilities/organization_integration.py
@@ -269,8 +269,17 @@ def integrate_sub_account(
                 environment_url, account_information, sub_account_session, sub_account, response_region, random_int, custom_tags, response_exclude_runbooks, wait=False)
 
         if eks_audit_logs:
+            # account_information["cloud_regions"] is still the backend's
+            # stale value from account creation (at most the CLI's own
+            # session region) - deploy_eks_audit_logs_stacks' own auto-detect
+            # fallback would scan only that if given account_information
+            # as-is, silently missing EKS clusters in any other active
+            # region. active_regions (just computed above via real EC2
+            # instance detection across all candidate regions) is what
+            # should be scanned instead.
             deploy_eks_audit_logs_stacks(
-                environment_url, account_information, sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
+                environment_url, {**account_information, "cloud_regions": active_regions},
+                sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
 
         # Updating the regions in StreamSecurity and waiting
         if not update_regions(graph_client, sub_account, active_regions, not parallel):

--- a/src/python/utilities/organization_integration.py
+++ b/src/python/utilities/organization_integration.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError:
 
 
 def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, parallel,
-         ws_id=None, custom_tags=None, regions_to_integrate=None, control_role="OrganizationAccountAccessRole", response=False, response_region="us-east-1", response_exclude_runbooks="", eks_audit_logs=False, eks_audit_logs_regions=None, api_token=None):
+         ws_id=None, custom_tags=None, regions_to_integrate=None, control_role="OrganizationAccountAccessRole", response=False, response_region="us-east-1", response_exclude_runbooks="", eks_audit_logs=False, eks_audit_logs_regions=None, eks_audit_logs_auto_detect=False, api_token=None):
 
     try:
         if not environment_url:
@@ -121,7 +121,8 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
                 executor.submit(
                     integrate_sub_account,
                     environment_url, sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate,
-                    control_role, org_account_id, parallel, response, response_region, response_exclude_runbooks, eks_audit_logs, eks_audit_logs_regions
+                    control_role, org_account_id, parallel, response, response_region, response_exclude_runbooks, eks_audit_logs, eks_audit_logs_regions,
+                    eks_audit_logs_auto_detect
                 ): sub_account for sub_account in sub_accounts
             }
             for future in concurrent.futures.as_completed(future_to_account):
@@ -138,7 +139,8 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
                 integrate_sub_account(
                     environment_url, sub_account, sts_client, graph_client, regions, random_int,
                     custom_tags, regions_to_integrate, control_role, org_account_id, response=response, response_region=response_region, response_exclude_runbooks=response_exclude_runbooks,
-                    eks_audit_logs=eks_audit_logs, eks_audit_logs_regions=eks_audit_logs_regions)
+                    eks_audit_logs=eks_audit_logs, eks_audit_logs_regions=eks_audit_logs_regions,
+                    eks_audit_logs_auto_detect=eks_audit_logs_auto_detect)
             except Exception as e:
                 failures.append((account_id, str(e)))
 
@@ -152,7 +154,8 @@ def main(environment_url, ll_username, ll_password, aws_profile_name, accounts, 
 
 def integrate_sub_account(
         environment_url, sub_account, sts_client, graph_client, regions, random_int, custom_tags, regions_to_integrate, control_role,
-        org_account_id, parallel=False, response=False, response_region="us-east-1", response_exclude_runbooks="", eks_audit_logs=False, eks_audit_logs_regions=None):
+        org_account_id, parallel=False, response=False, response_region="us-east-1", response_exclude_runbooks="", eks_audit_logs=False, eks_audit_logs_regions=None,
+        eks_audit_logs_auto_detect=False):
     print(color(f"Account: {sub_account[0]} | Starting integration", color="blue"))
     try:
         if sub_account[0] == org_account_id:
@@ -189,10 +192,14 @@ def integrate_sub_account(
                     deploy_response_stack(
                         environment_url ,sub_account_information, sub_account_session, sub_account, response_region, random_int, custom_tags, response_exclude_runbooks, wait=True)
                 
-                # Deploying EKS audit logs if enabled
-                if eks_audit_logs:
+                # Deploying EKS audit logs if enabled. eks_audit_logs_auto_detect
+                # forces auto-detection (regions=None) regardless of
+                # eks_audit_logs_regions - it's the explicit "just detect
+                # and deploy where EKS clusters are found" mode.
+                if eks_audit_logs or eks_audit_logs_auto_detect:
+                    regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
                     deploy_eks_audit_logs_stacks(
-                        environment_url, sub_account_information, sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
+                        environment_url, sub_account_information, sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
                 
                 print(color(f"Account: {sub_account[0]} | Checking if regions are updated", "blue"))
                 current_regions = sub_account_information["cloud_regions"]
@@ -268,7 +275,7 @@ def integrate_sub_account(
             deploy_response_stack(
                 environment_url, account_information, sub_account_session, sub_account, response_region, random_int, custom_tags, response_exclude_runbooks, wait=False)
 
-        if eks_audit_logs:
+        if eks_audit_logs or eks_audit_logs_auto_detect:
             # account_information["cloud_regions"] is still the backend's
             # stale value from account creation (at most the CLI's own
             # session region) - deploy_eks_audit_logs_stacks' own auto-detect
@@ -277,9 +284,13 @@ def integrate_sub_account(
             # region. active_regions (just computed above via real EC2
             # instance detection across all candidate regions) is what
             # should be scanned instead.
+            # eks_audit_logs_auto_detect forces auto-detection (regions=None)
+            # regardless of eks_audit_logs_regions - it's the explicit "just
+            # detect and deploy where EKS clusters are found" mode.
+            regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
             deploy_eks_audit_logs_stacks(
                 environment_url, {**account_information, "cloud_regions": active_regions},
-                sub_account_session, sub_account, eks_audit_logs_regions, random_int, custom_tags, wait=False)
+                sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
 
         # Updating the regions in StreamSecurity and waiting
         if not update_regions(graph_client, sub_account, active_regions, not parallel):
@@ -369,9 +380,17 @@ if __name__ == "__main__":
         "--eks_audit_logs", help="Enable EKS audit logs", action="store_true", required=False)
     parser.add_argument(
         "--eks_audit_logs_regions", help="Regions for EKS audit logs, separated by comma", required=False)
+    parser.add_argument(
+        "--eks_audit_logs_auto_detect",
+        help="Auto-detect active EKS regions per account (based on real EC2-instance-detected active "
+             "regions) and deploy the EKS audit-log stack only where clusters are actually found. "
+             "Independent of --eks_audit_logs/--eks_audit_logs_regions; overrides --eks_audit_logs_regions "
+             "if both are passed.",
+        action="store_true", required=False)
     args = parser.parse_args()
     main(args.environment_url, args.environment_user_name, args.environment_password,
          args.aws_profile_name, args.accounts, args.parallel,
          ws_id=args.ws_id, custom_tags=args.custom_tags, regions_to_integrate=args.regions,
          control_role=args.control_role, response=args.response, response_region=args.response_region, response_exclude_runbooks=args.response_exclude_runbooks,
-         eks_audit_logs=args.eks_audit_logs, eks_audit_logs_regions=args.eks_audit_logs_regions, api_token=args.api_token)
+         eks_audit_logs=args.eks_audit_logs, eks_audit_logs_regions=args.eks_audit_logs_regions,
+         eks_audit_logs_auto_detect=args.eks_audit_logs_auto_detect, api_token=args.api_token)

--- a/src/python/utilities/organization_integration.py
+++ b/src/python/utilities/organization_integration.py
@@ -191,22 +191,35 @@ def integrate_sub_account(
                 if (remediation is None or remediation.get("status") is None) and response:
                     deploy_response_stack(
                         environment_url ,sub_account_information, sub_account_session, sub_account, response_region, random_int, custom_tags, response_exclude_runbooks, wait=True)
-                
-                # Deploying EKS audit logs if enabled. eks_audit_logs_auto_detect
-                # forces auto-detection (regions=None) regardless of
-                # eks_audit_logs_regions - it's the explicit "just detect
-                # and deploy where EKS clusters are found" mode.
-                if eks_audit_logs or eks_audit_logs_auto_detect:
-                    regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
-                    deploy_eks_audit_logs_stacks(
-                        environment_url, sub_account_information, sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
-                
+
                 print(color(f"Account: {sub_account[0]} | Checking if regions are updated", "blue"))
                 current_regions = sub_account_information["cloud_regions"]
                 if regions_to_integrate:
                     potential_regions = regions_to_integrate
                 else:
                     potential_regions = get_active_regions(sub_account_session, regions)
+
+                # Deploying EKS audit logs if enabled. eks_audit_logs_auto_detect
+                # forces auto-detection (regions=None) regardless of
+                # eks_audit_logs_regions - it's the explicit "just detect and
+                # deploy where EKS clusters are found" mode, so it must scan
+                # potential_regions (real EC2-instance-detected active
+                # regions, just computed above), not
+                # sub_account_information["cloud_regions"] (the account's
+                # currently-registered region list in StreamSecurity, which
+                # may be stale if new regions became active since last
+                # onboarding). Plain --eks_audit_logs keeps its existing
+                # behavior (scanning cloud_regions) unchanged.
+                if eks_audit_logs or eks_audit_logs_auto_detect:
+                    regions_arg = None if eks_audit_logs_auto_detect else eks_audit_logs_regions
+                    # list(potential_regions): a copy, not a reference - it's
+                    # extended in place further down in this same function.
+                    eks_account_information = (
+                        {**sub_account_information, "cloud_regions": list(potential_regions)}
+                        if eks_audit_logs_auto_detect else sub_account_information)
+                    deploy_eks_audit_logs_stacks(
+                        environment_url, eks_account_information, sub_account_session, sub_account, regions_arg, random_int, custom_tags, wait=False)
+
                 if sorted(current_regions) != sorted(potential_regions):
                     potential_regions.extend(current_regions)
                     potential_regions = list(set(potential_regions))

--- a/tests/test_organization_integration_eks_regions.py
+++ b/tests/test_organization_integration_eks_regions.py
@@ -18,7 +18,9 @@ from src.python.utilities import organization_integration as oi
 
 
 class TestEksAuditLogsActiveRegions(unittest.TestCase):
-    def _run_brand_new_account(self, active_regions, backend_cloud_regions):
+    def _run_brand_new_account(self, active_regions, backend_cloud_regions,
+                               eks_audit_logs=True, eks_audit_logs_regions=None,
+                               eks_audit_logs_auto_detect=False):
         sts_client = MagicMock()
         graph_client = MagicMock()
         # First get_accounts() call (existence check) -> IndexError, so
@@ -48,7 +50,9 @@ class TestEksAuditLogsActiveRegions(unittest.TestCase):
                 "https://example.streamsec.io", ("111111111111", "acct"), sts_client, graph_client,
                 ["us-east-1", "us-west-2"], 12345678, None, None, "OrganizationAccountAccessRole",
                 "111111111111",  # org_account_id == sub_account -> no assume_role needed
-                parallel=False, response=False, eks_audit_logs=True, eks_audit_logs_regions=None,
+                parallel=False, response=False, eks_audit_logs=eks_audit_logs,
+                eks_audit_logs_regions=eks_audit_logs_regions,
+                eks_audit_logs_auto_detect=eks_audit_logs_auto_detect,
             )
 
         return mock_eks
@@ -83,6 +87,57 @@ class TestEksAuditLogsActiveRegions(unittest.TestCase):
         passed_account_information = mock_eks.call_args[0][1]
         self.assertEqual(passed_account_information["lightlytics_collection_token"], "tok")
         self.assertEqual(passed_account_information["cloud_account_id"], "111111111111")
+
+    def test_auto_detect_flag_alone_triggers_deploy_with_active_regions(self):
+        # --eks_audit_logs_auto_detect on its own (no --eks_audit_logs) must
+        # still trigger detection+deploy, scanning active_regions.
+        mock_eks = self._run_brand_new_account(
+            active_regions=["us-east-1", "us-west-2"],
+            backend_cloud_regions=["us-east-1"],
+            eks_audit_logs=False, eks_audit_logs_regions=None,
+            eks_audit_logs_auto_detect=True,
+        )
+        mock_eks.assert_called_once()
+        passed_account_information = mock_eks.call_args[0][1]
+        self.assertEqual(
+            sorted(passed_account_information["cloud_regions"]), ["us-east-1", "us-west-2"])
+        # regions_arg (5th positional) must be None so
+        # deploy_eks_audit_logs_stacks runs its own auto-detection.
+        self.assertIsNone(mock_eks.call_args[0][4])
+
+    def test_auto_detect_flag_overrides_explicit_regions(self):
+        # If both --eks_audit_logs_regions and --eks_audit_logs_auto_detect
+        # are passed, auto-detect wins - the explicit region list is ignored
+        # in favor of real detection.
+        mock_eks = self._run_brand_new_account(
+            active_regions=["us-east-1", "us-west-2"],
+            backend_cloud_regions=["us-east-1"],
+            eks_audit_logs=True, eks_audit_logs_regions=["eu-west-1"],
+            eks_audit_logs_auto_detect=True,
+        )
+        mock_eks.assert_called_once()
+        self.assertIsNone(mock_eks.call_args[0][4])
+
+    def test_neither_flag_skips_eks_entirely(self):
+        mock_eks = self._run_brand_new_account(
+            active_regions=["us-east-1", "us-west-2"],
+            backend_cloud_regions=["us-east-1"],
+            eks_audit_logs=False, eks_audit_logs_regions=None,
+            eks_audit_logs_auto_detect=False,
+        )
+        mock_eks.assert_not_called()
+
+    def test_explicit_eks_audit_logs_regions_still_respected_without_auto_detect(self):
+        # Existing behavior preserved: --eks_audit_logs_regions still passes
+        # through untouched when --eks_audit_logs_auto_detect isn't set.
+        mock_eks = self._run_brand_new_account(
+            active_regions=["us-east-1", "us-west-2"],
+            backend_cloud_regions=["us-east-1"],
+            eks_audit_logs=True, eks_audit_logs_regions=["eu-west-1"],
+            eks_audit_logs_auto_detect=False,
+        )
+        mock_eks.assert_called_once()
+        self.assertEqual(mock_eks.call_args[0][4], ["eu-west-1"])
 
 
 if __name__ == "__main__":

--- a/tests/test_organization_integration_eks_regions.py
+++ b/tests/test_organization_integration_eks_regions.py
@@ -139,6 +139,72 @@ class TestEksAuditLogsActiveRegions(unittest.TestCase):
         mock_eks.assert_called_once()
         self.assertEqual(mock_eks.call_args[0][4], ["eu-west-1"])
 
+    def _run_ready_account(self, potential_regions, registered_cloud_regions,
+                           eks_audit_logs=True, eks_audit_logs_regions=None,
+                           eks_audit_logs_auto_detect=False):
+        sts_client = MagicMock()
+        graph_client = MagicMock()
+        graph_client.get_accounts.return_value = [
+            {"cloud_account_id": "111111111111", "status": "READY",
+             "cloud_regions": registered_cloud_regions,
+             "realtime_regions": [{"region_name": r} for r in registered_cloud_regions],
+             "lightlytics_collection_token": "tok"},
+        ]
+        graph_client.get_account_response_config.return_value = {"remediation": {"status": "done"}}
+
+        session = MagicMock()
+        session.region_name = "us-east-1"
+
+        with patch.object(oi, "boto3") as oi_boto3, \
+                patch.object(oi, "get_active_regions", return_value=potential_regions), \
+                patch.object(oi, "deploy_eks_audit_logs_stacks") as mock_eks, \
+                patch.object(oi, "update_regions", return_value=True), \
+                patch.object(oi, "deploy_all_collection_stacks", return_value=None):
+            oi_boto3.Session.return_value = session
+
+            oi.integrate_sub_account(
+                "https://example.streamsec.io", ("111111111111", "acct"), sts_client, graph_client,
+                ["us-east-1", "us-west-2"], 12345678, None, None, "OrganizationAccountAccessRole",
+                "111111111111",  # org_account_id == sub_account -> no assume_role needed
+                parallel=False, response=False, eks_audit_logs=eks_audit_logs,
+                eks_audit_logs_regions=eks_audit_logs_regions,
+                eks_audit_logs_auto_detect=eks_audit_logs_auto_detect,
+            )
+
+        return mock_eks
+
+    def test_ready_account_auto_detect_uses_potential_regions_not_stale_registered_regions(self):
+        # Already-READY account whose real active AWS regions (potential_regions,
+        # via get_active_regions) have grown since last onboarding -
+        # --eks_audit_logs_auto_detect must scan the fresh set, not the
+        # account's currently-registered (possibly stale) cloud_regions.
+        mock_eks = self._run_ready_account(
+            potential_regions=["us-east-1", "us-west-2"],
+            registered_cloud_regions=["us-east-1"],
+            eks_audit_logs=False, eks_audit_logs_regions=None,
+            eks_audit_logs_auto_detect=True,
+        )
+        mock_eks.assert_called_once()
+        passed_account_information = mock_eks.call_args[0][1]
+        self.assertEqual(
+            sorted(passed_account_information["cloud_regions"]), ["us-east-1", "us-west-2"],
+            "auto-detect must scan potential_regions, not the stale registered cloud_regions")
+        self.assertIsNone(mock_eks.call_args[0][4])
+
+    def test_ready_account_plain_eks_audit_logs_keeps_existing_behavior(self):
+        # Plain --eks_audit_logs (no auto-detect) must keep scanning the
+        # account's registered cloud_regions exactly as before - no behavior
+        # change for anyone already relying on it.
+        mock_eks = self._run_ready_account(
+            potential_regions=["us-east-1", "us-west-2"],
+            registered_cloud_regions=["us-east-1"],
+            eks_audit_logs=True, eks_audit_logs_regions=None,
+            eks_audit_logs_auto_detect=False,
+        )
+        mock_eks.assert_called_once()
+        passed_account_information = mock_eks.call_args[0][1]
+        self.assertEqual(passed_account_information["cloud_regions"], ["us-east-1"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_organization_integration_eks_regions.py
+++ b/tests/test_organization_integration_eks_regions.py
@@ -1,0 +1,89 @@
+"""
+Regression test for a bug in EKS audit-log region detection: for a brand-new
+account, deploy_eks_audit_logs_stacks was called with account_information
+whose "cloud_regions" is still the backend's stale value from account
+creation (at most the caller's own session region), instead of the
+already-computed active_regions (real EC2-instance detection across all
+candidate regions). A brand-new account with EKS clusters only in a
+secondary region would silently never get an audit-log stack deployed
+there.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.python.utilities import organization_integration as oi
+
+
+class TestEksAuditLogsActiveRegions(unittest.TestCase):
+    def _run_brand_new_account(self, active_regions, backend_cloud_regions):
+        sts_client = MagicMock()
+        graph_client = MagicMock()
+        # First get_accounts() call (existence check) -> IndexError, so
+        # ll_integrated stays False and create_account() runs; second call
+        # (fetching account_information) returns the backend's own stale
+        # cloud_regions, mirroring what a real GraphQL create_account
+        # response looks like right after creation.
+        graph_client.get_accounts.side_effect = [
+            [],
+            [{"cloud_account_id": "111111111111", "cloud_regions": backend_cloud_regions,
+             "lightlytics_collection_token": "tok", "template_url": "https://example.com/t.yaml"}],
+        ]
+        graph_client.create_account.return_value = True
+
+        session = MagicMock()
+        session.region_name = "us-east-1"
+
+        with patch.object(oi, "boto3") as oi_boto3, \
+                patch.object(oi, "deploy_init_stack", return_value=True) as mock_init, \
+                patch.object(oi, "get_active_regions", return_value=active_regions), \
+                patch.object(oi, "deploy_eks_audit_logs_stacks") as mock_eks, \
+                patch.object(oi, "update_regions", return_value=True), \
+                patch.object(oi, "deploy_all_collection_stacks", return_value=None):
+            oi_boto3.Session.return_value = session
+
+            oi.integrate_sub_account(
+                "https://example.streamsec.io", ("111111111111", "acct"), sts_client, graph_client,
+                ["us-east-1", "us-west-2"], 12345678, None, None, "OrganizationAccountAccessRole",
+                "111111111111",  # org_account_id == sub_account -> no assume_role needed
+                parallel=False, response=False, eks_audit_logs=True, eks_audit_logs_regions=None,
+            )
+
+        return mock_eks
+
+    def test_eks_detection_uses_active_regions_not_stale_backend_regions(self):
+        mock_eks = self._run_brand_new_account(
+            active_regions=["us-east-1", "us-west-2"],
+            backend_cloud_regions=["us-east-1"],
+        )
+        mock_eks.assert_called_once()
+        call_args = mock_eks.call_args
+        passed_account_information = call_args[0][1]
+        self.assertEqual(
+            sorted(passed_account_information["cloud_regions"]), ["us-east-1", "us-west-2"],
+            "EKS detection must scan active_regions (real EC2-instance detection), "
+            "not the backend's stale cloud_regions from account creation")
+
+    def test_eks_detection_still_works_when_backend_regions_already_match(self):
+        mock_eks = self._run_brand_new_account(
+            active_regions=["us-east-1"],
+            backend_cloud_regions=["us-east-1"],
+        )
+        mock_eks.assert_called_once()
+        passed_account_information = mock_eks.call_args[0][1]
+        self.assertEqual(passed_account_information["cloud_regions"], ["us-east-1"])
+
+    def test_other_account_information_fields_are_preserved(self):
+        mock_eks = self._run_brand_new_account(
+            active_regions=["us-east-1", "us-west-2"],
+            backend_cloud_regions=["us-east-1"],
+        )
+        passed_account_information = mock_eks.call_args[0][1]
+        self.assertEqual(passed_account_information["lightlytics_collection_token"], "tok")
+        self.assertEqual(passed_account_information["cloud_account_id"], "111111111111")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Scoped to `organization_integration.py` only. The Lambda handler has the same underlying issues but is being handled separately.

- `deploy_eks_audit_logs_stacks` was called with `account_information` whose `cloud_regions` still reflected the backend's stale value from account creation (at most the caller's own session region), instead of the already-computed `active_regions` (real EC2-instance detection across all candidate regions) sitting right above it in the same function.
- Net effect: for a brand-new account, if EKS clusters exist only in a secondary region (not the CLI's own default/session region), the EKS audit-log stack would silently never get deployed there on first onboarding.
- Adds a new `--eks_audit_logs_auto_detect` flag: when passed, always runs EKS cluster auto-detection and deploys the audit-log stack only where clusters are actually found - independent of the pre-existing `--eks_audit_logs`/`--eks_audit_logs_regions` pair, and overriding `--eks_audit_logs_regions` if both are set.
- For already-integrated (READY) accounts, the EKS call happened before `potential_regions` (real EC2-instance-detected active regions) was even computed, so `--eks_audit_logs_auto_detect` was still scanning the account's currently-registered `cloud_regions` - stale if new regions became active since last onboarding. Reordered so `potential_regions` is computed first, and `--eks_audit_logs_auto_detect` now scans it instead. Plain `--eks_audit_logs` keeps its exact prior behavior (scanning `cloud_regions`) unchanged, per explicit decision to leave existing flag behavior alone.

## Test plan
- [x] `tests/test_organization_integration_eks_regions.py` - 9 tests covering: brand-new accounts scan `active_regions` not stale backend regions; `--eks_audit_logs_auto_detect` triggers detection on its own and overrides an explicit region list; existing `--eks_audit_logs`/`--eks_audit_logs_regions` behavior is unchanged when auto-detect isn't set; already-READY accounts scan freshly-detected `potential_regions` under auto-detect while plain `--eks_audit_logs` keeps scanning the account's registered regions
- [x] Full existing suite: `python3 -m pytest tests/ -q` -> 77 passed